### PR TITLE
Exporting LambdaFilterFields

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export type {
     QueryFilter,
     FilterFields,
     FilterOperators,
+    LambdaFilterFields
 } from './query-builder/types/filter/query-filter.type';
 export type { CombinedFilter } from './query-builder/types/filter/combined-filter.type';
 export type { Guid } from './query-builder/types/utils/util.types';


### PR DESCRIPTION
For some dynamic filter building scenarios, we should be able to build lambda fields on the fly.