### PR TITLE
v1.0.4: Allow comparison operators on string fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -226,9 +226,9 @@
             }
         },
         "node_modules/@eslint/config-array/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -310,9 +310,9 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -848,9 +848,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz",
-            "integrity": "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==",
+            "version": "4.59.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.1.tgz",
+            "integrity": "sha512-xB0b51TB7IfDEzAojXahmr+gfA00uYVInJGgNNkeQG6RPnCPGr7udsylFLTubuIUSRE6FkcI1NElyRt83PP5oQ==",
             "cpu": [
                 "arm"
             ],
@@ -863,9 +863,9 @@
             "peer": true
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.3.tgz",
-            "integrity": "sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==",
+            "version": "4.59.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.1.tgz",
+            "integrity": "sha512-XOjPId0qwSDKHaIsdzHJtKCxX0+nH8MhBwvrNsT7tVyKmdTx1jJ4XzN5RZXCdTzMpufLb+B8llTC0D8uCrLhcw==",
             "cpu": [
                 "arm64"
             ],
@@ -878,9 +878,9 @@
             "peer": true
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.3.tgz",
-            "integrity": "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==",
+            "version": "4.59.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.1.tgz",
+            "integrity": "sha512-vQuRd28p0gQpPrS6kppd8IrWmFo42U8Pz1XLRjSZXq5zCqyMDYFABT7/sywL11mO1EL10Qhh7MVPEwkG8GiBeg==",
             "cpu": [
                 "arm64"
             ],
@@ -893,9 +893,9 @@
             "peer": true
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.3.tgz",
-            "integrity": "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==",
+            "version": "4.59.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.1.tgz",
+            "integrity": "sha512-x6VG6U29+Ivlnajrg1IHdzXeAwSoEHBFVO+CtC9Brugx6de712CUJobRUxsIA0KYrQvCmzNrMPFTT1A4CCqNTg==",
             "cpu": [
                 "x64"
             ],
@@ -908,9 +908,9 @@
             "peer": true
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.3.tgz",
-            "integrity": "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==",
+            "version": "4.59.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.1.tgz",
+            "integrity": "sha512-Sgi0Uo6t1YCHJMNO3Y8+bm+SvOanUGkoZKn/VJPwYUe2kp31X5KnXmzKd/NjW8iA3gFcfNZ64zh14uOGrIllCQ==",
             "cpu": [
                 "arm64"
             ],
@@ -923,9 +923,9 @@
             "peer": true
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.3.tgz",
-            "integrity": "sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==",
+            "version": "4.59.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.1.tgz",
+            "integrity": "sha512-AM4xnwEZwukdhk7laMWfzWu9JGSVnJd+Fowt6Fd7QW1nrf3h0Hp7Qx5881M4aqrUlKBCybOxz0jofvIIfl7C5g==",
             "cpu": [
                 "x64"
             ],
@@ -938,9 +938,9 @@
             "peer": true
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.3.tgz",
-            "integrity": "sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==",
+            "version": "4.59.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.1.tgz",
+            "integrity": "sha512-KUizqxpwaR2AZdAUsMWfL/C94pUu7TKpoPd88c8yFVixJ+l9hejkrwoK5Zj3wiNh65UeyryKnJyxL1b7yNqFQA==",
             "cpu": [
                 "arm"
             ],
@@ -953,9 +953,9 @@
             "peer": true
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.3.tgz",
-            "integrity": "sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==",
+            "version": "4.59.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.1.tgz",
+            "integrity": "sha512-MZoQ/am77ckJtZGFAtPucgUuJWiop3m2R3lw7tC0QCcbfl4DRhQUBUkHWCkcrT3pqy5Mzv5QQgY6Dmlba6iTWg==",
             "cpu": [
                 "arm"
             ],
@@ -968,9 +968,9 @@
             "peer": true
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.3.tgz",
-            "integrity": "sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==",
+            "version": "4.59.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.1.tgz",
+            "integrity": "sha512-Sez95TP6xGjkWB1608EfhCX1gdGrO5wzyN99VqzRtC17x/1bhw5VU1V0GfKUwbW/Xr1J8mSasoFoJa6Y7aGGSA==",
             "cpu": [
                 "arm64"
             ],
@@ -983,9 +983,9 @@
             "peer": true
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.3.tgz",
-            "integrity": "sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==",
+            "version": "4.59.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.1.tgz",
+            "integrity": "sha512-9Cs2Seq98LWNOJzR89EGTZoiP8EkZ9UbQhBlDgfAkM6asVna1xJ04W2CLYWDN/RpUgOjtQvcv8wQVi1t5oQazA==",
             "cpu": [
                 "arm64"
             ],
@@ -998,9 +998,24 @@
             "peer": true
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.3.tgz",
-            "integrity": "sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==",
+            "version": "4.59.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.1.tgz",
+            "integrity": "sha512-n9yqttftgFy7IrNEnHy1bOp6B4OSe8mJDiPkT7EqlM9FnKOwUMnCK62ixW0Kd9Clw0/wgvh8+SqaDXMFvw3KqQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true
+        },
+        "node_modules/@rollup/rollup-linux-loong64-musl": {
+            "version": "4.59.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.1.tgz",
+            "integrity": "sha512-SfpNXDzVTqs/riak4xXcLpq5gIQWsqGWMhN1AGRQKB4qGSs4r0sEs3ervXPcE1O9RsQ5bm8Muz6zmQpQnPss1g==",
             "cpu": [
                 "loong64"
             ],
@@ -1013,9 +1028,24 @@
             "peer": true
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.3.tgz",
-            "integrity": "sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==",
+            "version": "4.59.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.1.tgz",
+            "integrity": "sha512-LjaChED0wQnjKZU+tsmGbN+9nN1XhaWUkAlSbTdhpEseCS4a15f/Q8xC2BN4GDKRzhhLZpYtJBZr2NZhR0jvNw==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-musl": {
+            "version": "4.59.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.1.tgz",
+            "integrity": "sha512-ojW7iTJSIs4pwB2xV6QXGwNyDctvXOivYllttuPbXguuKDX5vwpqYJsHc6D2LZzjDGHML414Tuj3LvVPe1CT1A==",
             "cpu": [
                 "ppc64"
             ],
@@ -1028,9 +1058,9 @@
             "peer": true
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.3.tgz",
-            "integrity": "sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==",
+            "version": "4.59.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.1.tgz",
+            "integrity": "sha512-FP+Q6WTcxxvsr0wQczhSE+tOZvFPV8A/mUE6mhZYFW9/eea/y/XqAgRoLLMuE9Cz0hfX5bi7p116IWoB+P237A==",
             "cpu": [
                 "riscv64"
             ],
@@ -1043,9 +1073,9 @@
             "peer": true
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.3.tgz",
-            "integrity": "sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==",
+            "version": "4.59.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.1.tgz",
+            "integrity": "sha512-L1uD9b/Ig8Z+rn1KttCJjwhN1FgjRMBKsPaBsDKkfUl7GfFq71pU4vWCnpOsGljycFEbkHWARZLf4lMYg3WOLw==",
             "cpu": [
                 "riscv64"
             ],
@@ -1058,9 +1088,9 @@
             "peer": true
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.3.tgz",
-            "integrity": "sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==",
+            "version": "4.59.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.1.tgz",
+            "integrity": "sha512-EZc9NGTk/oSUzzOD4nYY4gIjteo2M3CiozX6t1IXGCOdgxJTlVu/7EdPeiqeHPSIrxkLhavqpBAUCfvC6vBOug==",
             "cpu": [
                 "s390x"
             ],
@@ -1073,9 +1103,9 @@
             "peer": true
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz",
-            "integrity": "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==",
+            "version": "4.59.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.1.tgz",
+            "integrity": "sha512-NQ9KyU1Anuy59L8+HHOKM++CoUxrQWrZWXRik4BJFm+7i5NP6q/SW43xIBr80zzt+PDBJ7LeNmloQGfa0JGk0w==",
             "cpu": [
                 "x64"
             ],
@@ -1088,9 +1118,9 @@
             "peer": true
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.3.tgz",
-            "integrity": "sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==",
+            "version": "4.59.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.1.tgz",
+            "integrity": "sha512-GZkLk2t6naywsveSFBsEb0PLU+JC9ggVjbndsbG20VPhar6D1gkMfCx4NfP9owpovBXTN+eRdqGSkDGIxPHhmQ==",
             "cpu": [
                 "x64"
             ],
@@ -1102,10 +1132,25 @@
             ],
             "peer": true
         },
+        "node_modules/@rollup/rollup-openbsd-x64": {
+            "version": "4.59.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.1.tgz",
+            "integrity": "sha512-1hjG9Jpl2KDOetr64iQd8AZAEjkDUUK5RbDkYWsViYLC1op1oNzdjMJeFiofcGhqbNTaY2kfgqowE7DILifsrA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "peer": true
+        },
         "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.3.tgz",
-            "integrity": "sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==",
+            "version": "4.59.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.1.tgz",
+            "integrity": "sha512-ARoKfflk0SiiYm3r1fmF73K/yB+PThmOwfWCk1sr7x/k9dc3uGLWuEE9if+Pw21el8MSpp3TMnG5vLNsJ/MMGQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1118,9 +1163,9 @@
             "peer": true
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.3.tgz",
-            "integrity": "sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==",
+            "version": "4.59.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.1.tgz",
+            "integrity": "sha512-oOST61G6VM45Mz2vdzWMr1s2slI7y9LqxEV5fCoWi2MDONmMvgsJVHSXxce/I2xOSZPTZ47nDPOl1tkwKWSHcw==",
             "cpu": [
                 "arm64"
             ],
@@ -1133,9 +1178,9 @@
             "peer": true
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.3.tgz",
-            "integrity": "sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==",
+            "version": "4.59.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.1.tgz",
+            "integrity": "sha512-x5WgLi5dWpRz7WclKBGEF15LcWTh0ewrHM6Cq4A+WUbkysUMZNeqt05bwPonOQ3ihPS/WMhAZV5zB1DfnI4Sxg==",
             "cpu": [
                 "ia32"
             ],
@@ -1148,9 +1193,9 @@
             "peer": true
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.3.tgz",
-            "integrity": "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==",
+            "version": "4.59.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.1.tgz",
+            "integrity": "sha512-wS+zHAJRVP5zOL0e+a3V3E/NTEwM2HEvvNKoDy5Xcfs0o8lljxn+EAFPkUsxihBdmDq1JWzXmmB9cbssCPdxxw==",
             "cpu": [
                 "x64"
             ],
@@ -1163,9 +1208,9 @@
             "peer": true
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.3.tgz",
-            "integrity": "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==",
+            "version": "4.59.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.1.tgz",
+            "integrity": "sha512-rhHyrMeLpErT/C7BxcEsU4COHQUzHyrPYW5tOZUeUhziNtRuYxmDWvqQqzpuUt8xpOgmbKa1btGXfnA/ANVO+g==",
             "cpu": [
                 "x64"
             ],
@@ -1690,9 +1735,9 @@
             }
         },
         "node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+            "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1941,9 +1986,9 @@
             }
         },
         "node_modules/diff": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+            "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -2142,9 +2187,9 @@
             }
         },
         "node_modules/eslint/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -3263,9 +3308,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.53.3",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
-            "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
+            "version": "4.59.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.1.tgz",
+            "integrity": "sha512-iZKH8BeoCwTCBTZBZWQQMreekd4mdomwdjIQ40GC1oZm6o+8PnNMIxFOiCsGMWeS8iDJ7KZcl7KwmKk/0HOQpA==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -3280,28 +3325,31 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.53.3",
-                "@rollup/rollup-android-arm64": "4.53.3",
-                "@rollup/rollup-darwin-arm64": "4.53.3",
-                "@rollup/rollup-darwin-x64": "4.53.3",
-                "@rollup/rollup-freebsd-arm64": "4.53.3",
-                "@rollup/rollup-freebsd-x64": "4.53.3",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.53.3",
-                "@rollup/rollup-linux-arm-musleabihf": "4.53.3",
-                "@rollup/rollup-linux-arm64-gnu": "4.53.3",
-                "@rollup/rollup-linux-arm64-musl": "4.53.3",
-                "@rollup/rollup-linux-loong64-gnu": "4.53.3",
-                "@rollup/rollup-linux-ppc64-gnu": "4.53.3",
-                "@rollup/rollup-linux-riscv64-gnu": "4.53.3",
-                "@rollup/rollup-linux-riscv64-musl": "4.53.3",
-                "@rollup/rollup-linux-s390x-gnu": "4.53.3",
-                "@rollup/rollup-linux-x64-gnu": "4.53.3",
-                "@rollup/rollup-linux-x64-musl": "4.53.3",
-                "@rollup/rollup-openharmony-arm64": "4.53.3",
-                "@rollup/rollup-win32-arm64-msvc": "4.53.3",
-                "@rollup/rollup-win32-ia32-msvc": "4.53.3",
-                "@rollup/rollup-win32-x64-gnu": "4.53.3",
-                "@rollup/rollup-win32-x64-msvc": "4.53.3",
+                "@rollup/rollup-android-arm-eabi": "4.59.1",
+                "@rollup/rollup-android-arm64": "4.59.1",
+                "@rollup/rollup-darwin-arm64": "4.59.1",
+                "@rollup/rollup-darwin-x64": "4.59.1",
+                "@rollup/rollup-freebsd-arm64": "4.59.1",
+                "@rollup/rollup-freebsd-x64": "4.59.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.59.1",
+                "@rollup/rollup-linux-arm-musleabihf": "4.59.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.59.1",
+                "@rollup/rollup-linux-arm64-musl": "4.59.1",
+                "@rollup/rollup-linux-loong64-gnu": "4.59.1",
+                "@rollup/rollup-linux-loong64-musl": "4.59.1",
+                "@rollup/rollup-linux-ppc64-gnu": "4.59.1",
+                "@rollup/rollup-linux-ppc64-musl": "4.59.1",
+                "@rollup/rollup-linux-riscv64-gnu": "4.59.1",
+                "@rollup/rollup-linux-riscv64-musl": "4.59.1",
+                "@rollup/rollup-linux-s390x-gnu": "4.59.1",
+                "@rollup/rollup-linux-x64-gnu": "4.59.1",
+                "@rollup/rollup-linux-x64-musl": "4.59.1",
+                "@rollup/rollup-openbsd-x64": "4.59.1",
+                "@rollup/rollup-openharmony-arm64": "4.59.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.59.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.59.1",
+                "@rollup/rollup-win32-x64-gnu": "4.59.1",
+                "@rollup/rollup-win32-x64-msvc": "4.59.1",
                 "fsevents": "~2.3.2"
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "odata-builder",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "odata-builder",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "license": "MIT",
             "devDependencies": {
                 "@rollup/plugin-terser": "^1.0.0",
@@ -73,9 +73,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-            "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -136,446 +136,38 @@
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
-        "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
-            "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
-            "cpu": [
-                "ppc64"
-            ],
+        "node_modules/@emnapi/core": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+            "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "aix"
-            ],
-            "engines": {
-                "node": ">=18"
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.0",
+                "tslib": "^2.4.0"
             }
         },
-        "node_modules/@esbuild/android-arm": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
-            "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
-            "cpu": [
-                "arm"
-            ],
+        "node_modules/@emnapi/runtime": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+            "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
+            "dependencies": {
+                "tslib": "^2.4.0"
             }
         },
-        "node_modules/@esbuild/android-arm64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
-            "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
-            "cpu": [
-                "arm64"
-            ],
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+            "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/android-x64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
-            "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
-            "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/darwin-x64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
-            "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
-            "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
-            "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-arm": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
-            "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-arm64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
-            "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-ia32": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
-            "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-loong64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
-            "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
-            "cpu": [
-                "loong64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
-            "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
-            "cpu": [
-                "mips64el"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
-            "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
-            "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-s390x": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
-            "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
-            "cpu": [
-                "s390x"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/linux-x64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
-            "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
-            "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
-            "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
-            "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
-            "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
-            "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openharmony"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/sunos-x64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
-            "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "sunos"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/win32-arm64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
-            "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/win32-ia32": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
-            "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@esbuild/win32-x64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
-            "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
+            "dependencies": {
+                "tslib": "^2.4.0"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -634,9 +226,9 @@
             }
         },
         "node_modules/@eslint/config-array/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -673,20 +265,20 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "3.3.5",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-            "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
+            "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ajv": "^6.14.0",
+                "ajv": "^6.12.4",
                 "debug": "^4.3.2",
                 "espree": "^10.0.1",
                 "globals": "^14.0.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
                 "js-yaml": "^4.1.1",
-                "minimatch": "^3.1.5",
+                "minimatch": "^3.1.2",
                 "strip-json-comments": "^3.1.1"
             },
             "engines": {
@@ -718,9 +310,9 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -880,6 +472,33 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+            "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1",
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@oxc-project/types": {
+            "version": "0.120.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.120.0.tgz",
+            "integrity": "sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
         "node_modules/@pkgr/core": {
             "version": "0.2.9",
             "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
@@ -892,6 +511,268 @@
             "funding": {
                 "url": "https://opencollective.com/pkgr"
             }
+        },
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.10.tgz",
+            "integrity": "sha512-jOHxwXhxmFKuXztiu1ORieJeTbx5vrTkcOkkkn2d35726+iwhrY1w/+nYY/AGgF12thg33qC3R1LMBF5tHTZHg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.10.tgz",
+            "integrity": "sha512-gED05Teg/vtTZbIJBc4VNMAxAFDUPkuO/rAIyyxZjTj1a1/s6z5TII/5yMGZ0uLRCifEtwUQn8OlYzuYc0m70w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.10.tgz",
+            "integrity": "sha512-rI15NcM1mA48lqrIxVkHfAqcyFLcQwyXWThy+BQ5+mkKKPvSO26ir+ZDp36AgYoYVkqvMcdS8zOE6SeBsR9e8A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.10.tgz",
+            "integrity": "sha512-XZRXHdTa+4ME1MuDVp021+doQ+z6Ei4CCFmNc5/sKbqb8YmkiJdj8QKlV3rCI0AJtAeSB5n0WGPuJWNL9p/L2w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.10.tgz",
+            "integrity": "sha512-R0SQMRluISSLzFE20sPWYHVmJdDQnRyc/FzSCN72BqQmh2SOZUFG+N3/vBZpR4C6WpEUVYJLrYUXaj43sJsNLA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.10.tgz",
+            "integrity": "sha512-Y1reMrV/o+cwpduYhJuOE3OMKx32RMYCidf14y+HssARRmhDuWXJ4yVguDg2R/8SyyGNo+auzz64LnPK9Hq6jg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.10.tgz",
+            "integrity": "sha512-vELN+HNb2IzuzSBUOD4NHmP9yrGwl1DVM29wlQvx1OLSclL0NgVWnVDKl/8tEks79EFek/kebQKnNJkIAA4W2g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.10.tgz",
+            "integrity": "sha512-ZqrufYTgzxbHwpqOjzSsb0UV/aV2TFIY5rP8HdsiPTv/CuAgCRjM6s9cYFwQ4CNH+hf9Y4erHW1GjZuZ7WoI7w==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.10.tgz",
+            "integrity": "sha512-gSlmVS1FZJSRicA6IyjoRoKAFK7IIHBs7xJuHRSmjImqk3mPPWbR7RhbnfH2G6bcmMEllCt2vQ/7u9e6bBnByg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.10.tgz",
+            "integrity": "sha512-eOCKUpluKgfObT2pHjztnaWEIbUabWzk3qPZ5PuacuPmr4+JtQG4k2vGTY0H15edaTnicgU428XW/IH6AimcQw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.10.tgz",
+            "integrity": "sha512-Xdf2jQbfQowJnLcgYfD/m0Uu0Qj5OdxKallD78/IPPfzaiaI4KRAwZzHcKQ4ig1gtg1SuzC7jovNiM2TzQsBXA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.10.tgz",
+            "integrity": "sha512-o1hYe8hLi1EY6jgPFyxQgQ1wcycX+qz8eEbVmot2hFkgUzPxy9+kF0u0NIQBeDq+Mko47AkaFFaChcvZa9UX9Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.10.tgz",
+            "integrity": "sha512-Ugv9o7qYJudqQO5Y5y2N2SOo6S4WiqiNOpuQyoPInnhVzCY+wi/GHltcLHypG9DEUYMB0iTB/huJrpadiAcNcA==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@napi-rs/wasm-runtime": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.10.tgz",
+            "integrity": "sha512-7UODQb4fQUNT/vmgDZBl3XOBAIOutP5R3O/rkxg0aLfEGQ4opbCgU5vOw/scPe4xOqBwL9fw7/RP1vAMZ6QlAQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.10.tgz",
+            "integrity": "sha512-PYxKHMVHOb5NJuDL53vBUl1VwUjymDcYI6rzpIni0C9+9mTiJedvUxSk7/RPp7OOAm3v+EjgMu9bIy3N6b408w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.10.tgz",
+            "integrity": "sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@rollup/plugin-terser": {
             "version": "1.0.0",
@@ -967,9 +848,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.59.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.1.tgz",
-            "integrity": "sha512-xB0b51TB7IfDEzAojXahmr+gfA00uYVInJGgNNkeQG6RPnCPGr7udsylFLTubuIUSRE6FkcI1NElyRt83PP5oQ==",
+            "version": "4.53.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz",
+            "integrity": "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==",
             "cpu": [
                 "arm"
             ],
@@ -978,12 +859,13 @@
             "optional": true,
             "os": [
                 "android"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.59.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.1.tgz",
-            "integrity": "sha512-XOjPId0qwSDKHaIsdzHJtKCxX0+nH8MhBwvrNsT7tVyKmdTx1jJ4XzN5RZXCdTzMpufLb+B8llTC0D8uCrLhcw==",
+            "version": "4.53.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.3.tgz",
+            "integrity": "sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==",
             "cpu": [
                 "arm64"
             ],
@@ -992,12 +874,13 @@
             "optional": true,
             "os": [
                 "android"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.59.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.1.tgz",
-            "integrity": "sha512-vQuRd28p0gQpPrS6kppd8IrWmFo42U8Pz1XLRjSZXq5zCqyMDYFABT7/sywL11mO1EL10Qhh7MVPEwkG8GiBeg==",
+            "version": "4.53.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.3.tgz",
+            "integrity": "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==",
             "cpu": [
                 "arm64"
             ],
@@ -1006,12 +889,13 @@
             "optional": true,
             "os": [
                 "darwin"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.59.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.1.tgz",
-            "integrity": "sha512-x6VG6U29+Ivlnajrg1IHdzXeAwSoEHBFVO+CtC9Brugx6de712CUJobRUxsIA0KYrQvCmzNrMPFTT1A4CCqNTg==",
+            "version": "4.53.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.3.tgz",
+            "integrity": "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==",
             "cpu": [
                 "x64"
             ],
@@ -1020,12 +904,13 @@
             "optional": true,
             "os": [
                 "darwin"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.59.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.1.tgz",
-            "integrity": "sha512-Sgi0Uo6t1YCHJMNO3Y8+bm+SvOanUGkoZKn/VJPwYUe2kp31X5KnXmzKd/NjW8iA3gFcfNZ64zh14uOGrIllCQ==",
+            "version": "4.53.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.3.tgz",
+            "integrity": "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==",
             "cpu": [
                 "arm64"
             ],
@@ -1034,12 +919,13 @@
             "optional": true,
             "os": [
                 "freebsd"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.59.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.1.tgz",
-            "integrity": "sha512-AM4xnwEZwukdhk7laMWfzWu9JGSVnJd+Fowt6Fd7QW1nrf3h0Hp7Qx5881M4aqrUlKBCybOxz0jofvIIfl7C5g==",
+            "version": "4.53.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.3.tgz",
+            "integrity": "sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==",
             "cpu": [
                 "x64"
             ],
@@ -1048,12 +934,13 @@
             "optional": true,
             "os": [
                 "freebsd"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.59.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.1.tgz",
-            "integrity": "sha512-KUizqxpwaR2AZdAUsMWfL/C94pUu7TKpoPd88c8yFVixJ+l9hejkrwoK5Zj3wiNh65UeyryKnJyxL1b7yNqFQA==",
+            "version": "4.53.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.3.tgz",
+            "integrity": "sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==",
             "cpu": [
                 "arm"
             ],
@@ -1062,12 +949,13 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.59.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.1.tgz",
-            "integrity": "sha512-MZoQ/am77ckJtZGFAtPucgUuJWiop3m2R3lw7tC0QCcbfl4DRhQUBUkHWCkcrT3pqy5Mzv5QQgY6Dmlba6iTWg==",
+            "version": "4.53.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.3.tgz",
+            "integrity": "sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==",
             "cpu": [
                 "arm"
             ],
@@ -1076,12 +964,13 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.59.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.1.tgz",
-            "integrity": "sha512-Sez95TP6xGjkWB1608EfhCX1gdGrO5wzyN99VqzRtC17x/1bhw5VU1V0GfKUwbW/Xr1J8mSasoFoJa6Y7aGGSA==",
+            "version": "4.53.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.3.tgz",
+            "integrity": "sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==",
             "cpu": [
                 "arm64"
             ],
@@ -1090,12 +979,13 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.59.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.1.tgz",
-            "integrity": "sha512-9Cs2Seq98LWNOJzR89EGTZoiP8EkZ9UbQhBlDgfAkM6asVna1xJ04W2CLYWDN/RpUgOjtQvcv8wQVi1t5oQazA==",
+            "version": "4.53.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.3.tgz",
+            "integrity": "sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==",
             "cpu": [
                 "arm64"
             ],
@@ -1104,12 +994,13 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.59.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.1.tgz",
-            "integrity": "sha512-n9yqttftgFy7IrNEnHy1bOp6B4OSe8mJDiPkT7EqlM9FnKOwUMnCK62ixW0Kd9Clw0/wgvh8+SqaDXMFvw3KqQ==",
+            "version": "4.53.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.3.tgz",
+            "integrity": "sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==",
             "cpu": [
                 "loong64"
             ],
@@ -1118,26 +1009,13 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-loong64-musl": {
-            "version": "4.59.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.1.tgz",
-            "integrity": "sha512-SfpNXDzVTqs/riak4xXcLpq5gIQWsqGWMhN1AGRQKB4qGSs4r0sEs3ervXPcE1O9RsQ5bm8Muz6zmQpQnPss1g==",
-            "cpu": [
-                "loong64"
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.59.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.1.tgz",
-            "integrity": "sha512-LjaChED0wQnjKZU+tsmGbN+9nN1XhaWUkAlSbTdhpEseCS4a15f/Q8xC2BN4GDKRzhhLZpYtJBZr2NZhR0jvNw==",
+            "version": "4.53.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.3.tgz",
+            "integrity": "sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==",
             "cpu": [
                 "ppc64"
             ],
@@ -1146,26 +1024,13 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-linux-ppc64-musl": {
-            "version": "4.59.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.1.tgz",
-            "integrity": "sha512-ojW7iTJSIs4pwB2xV6QXGwNyDctvXOivYllttuPbXguuKDX5vwpqYJsHc6D2LZzjDGHML414Tuj3LvVPe1CT1A==",
-            "cpu": [
-                "ppc64"
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ]
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.59.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.1.tgz",
-            "integrity": "sha512-FP+Q6WTcxxvsr0wQczhSE+tOZvFPV8A/mUE6mhZYFW9/eea/y/XqAgRoLLMuE9Cz0hfX5bi7p116IWoB+P237A==",
+            "version": "4.53.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.3.tgz",
+            "integrity": "sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==",
             "cpu": [
                 "riscv64"
             ],
@@ -1174,12 +1039,13 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.59.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.1.tgz",
-            "integrity": "sha512-L1uD9b/Ig8Z+rn1KttCJjwhN1FgjRMBKsPaBsDKkfUl7GfFq71pU4vWCnpOsGljycFEbkHWARZLf4lMYg3WOLw==",
+            "version": "4.53.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.3.tgz",
+            "integrity": "sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==",
             "cpu": [
                 "riscv64"
             ],
@@ -1188,12 +1054,13 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.59.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.1.tgz",
-            "integrity": "sha512-EZc9NGTk/oSUzzOD4nYY4gIjteo2M3CiozX6t1IXGCOdgxJTlVu/7EdPeiqeHPSIrxkLhavqpBAUCfvC6vBOug==",
+            "version": "4.53.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.3.tgz",
+            "integrity": "sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==",
             "cpu": [
                 "s390x"
             ],
@@ -1202,12 +1069,13 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.59.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.1.tgz",
-            "integrity": "sha512-NQ9KyU1Anuy59L8+HHOKM++CoUxrQWrZWXRik4BJFm+7i5NP6q/SW43xIBr80zzt+PDBJ7LeNmloQGfa0JGk0w==",
+            "version": "4.53.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz",
+            "integrity": "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==",
             "cpu": [
                 "x64"
             ],
@@ -1216,12 +1084,13 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.59.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.1.tgz",
-            "integrity": "sha512-GZkLk2t6naywsveSFBsEb0PLU+JC9ggVjbndsbG20VPhar6D1gkMfCx4NfP9owpovBXTN+eRdqGSkDGIxPHhmQ==",
+            "version": "4.53.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.3.tgz",
+            "integrity": "sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==",
             "cpu": [
                 "x64"
             ],
@@ -1230,26 +1099,13 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
-        },
-        "node_modules/@rollup/rollup-openbsd-x64": {
-            "version": "4.59.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.1.tgz",
-            "integrity": "sha512-1hjG9Jpl2KDOetr64iQd8AZAEjkDUUK5RbDkYWsViYLC1op1oNzdjMJeFiofcGhqbNTaY2kfgqowE7DILifsrA==",
-            "cpu": [
-                "x64"
             ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ]
+            "peer": true
         },
         "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.59.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.1.tgz",
-            "integrity": "sha512-ARoKfflk0SiiYm3r1fmF73K/yB+PThmOwfWCk1sr7x/k9dc3uGLWuEE9if+Pw21el8MSpp3TMnG5vLNsJ/MMGQ==",
+            "version": "4.53.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.3.tgz",
+            "integrity": "sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==",
             "cpu": [
                 "arm64"
             ],
@@ -1258,12 +1114,13 @@
             "optional": true,
             "os": [
                 "openharmony"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.59.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.1.tgz",
-            "integrity": "sha512-oOST61G6VM45Mz2vdzWMr1s2slI7y9LqxEV5fCoWi2MDONmMvgsJVHSXxce/I2xOSZPTZ47nDPOl1tkwKWSHcw==",
+            "version": "4.53.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.3.tgz",
+            "integrity": "sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==",
             "cpu": [
                 "arm64"
             ],
@@ -1272,12 +1129,13 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.59.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.1.tgz",
-            "integrity": "sha512-x5WgLi5dWpRz7WclKBGEF15LcWTh0ewrHM6Cq4A+WUbkysUMZNeqt05bwPonOQ3ihPS/WMhAZV5zB1DfnI4Sxg==",
+            "version": "4.53.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.3.tgz",
+            "integrity": "sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==",
             "cpu": [
                 "ia32"
             ],
@@ -1286,12 +1144,13 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.59.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.1.tgz",
-            "integrity": "sha512-wS+zHAJRVP5zOL0e+a3V3E/NTEwM2HEvvNKoDy5Xcfs0o8lljxn+EAFPkUsxihBdmDq1JWzXmmB9cbssCPdxxw==",
+            "version": "4.53.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.3.tgz",
+            "integrity": "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==",
             "cpu": [
                 "x64"
             ],
@@ -1300,12 +1159,13 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.59.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.1.tgz",
-            "integrity": "sha512-rhHyrMeLpErT/C7BxcEsU4COHQUzHyrPYW5tOZUeUhziNtRuYxmDWvqQqzpuUt8xpOgmbKa1btGXfnA/ANVO+g==",
+            "version": "4.53.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.3.tgz",
+            "integrity": "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==",
             "cpu": [
                 "x64"
             ],
@@ -1314,7 +1174,8 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@standard-schema/spec": {
             "version": "1.1.0",
@@ -1350,6 +1211,17 @@
             "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
         },
         "node_modules/@types/chai": {
             "version": "5.2.3",
@@ -1395,20 +1267,20 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.50.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.50.0.tgz",
-            "integrity": "sha512-O7QnmOXYKVtPrfYzMolrCTfkezCJS9+ljLdKW/+DCvRsc3UAz+sbH6Xcsv7p30+0OwUbeWfUDAQE0vpabZ3QLg==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.1.tgz",
+            "integrity": "sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.50.0",
-                "@typescript-eslint/type-utils": "8.50.0",
-                "@typescript-eslint/utils": "8.50.0",
-                "@typescript-eslint/visitor-keys": "8.50.0",
-                "ignore": "^7.0.0",
+                "@eslint-community/regexpp": "^4.12.2",
+                "@typescript-eslint/scope-manager": "8.57.1",
+                "@typescript-eslint/type-utils": "8.57.1",
+                "@typescript-eslint/utils": "8.57.1",
+                "@typescript-eslint/visitor-keys": "8.57.1",
+                "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
-                "ts-api-utils": "^2.1.0"
+                "ts-api-utils": "^2.4.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1418,23 +1290,23 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.50.0",
-                "eslint": "^8.57.0 || ^9.0.0",
+                "@typescript-eslint/parser": "^8.57.1",
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.50.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.50.0.tgz",
-            "integrity": "sha512-6/cmF2piao+f6wSxUsJLZjck7OQsYyRtcOZS02k7XINSNlz93v6emM8WutDQSXnroG2xwYlEVHJI+cPA7CPM3Q==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.1.tgz",
+            "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.50.0",
-                "@typescript-eslint/types": "8.50.0",
-                "@typescript-eslint/typescript-estree": "8.50.0",
-                "@typescript-eslint/visitor-keys": "8.50.0",
-                "debug": "^4.3.4"
+                "@typescript-eslint/scope-manager": "8.57.1",
+                "@typescript-eslint/types": "8.57.1",
+                "@typescript-eslint/typescript-estree": "8.57.1",
+                "@typescript-eslint/visitor-keys": "8.57.1",
+                "debug": "^4.4.3"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1444,20 +1316,20 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0",
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.50.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.50.0.tgz",
-            "integrity": "sha512-Cg/nQcL1BcoTijEWyx4mkVC56r8dj44bFDvBdygifuS20f3OZCHmFbjF34DPSi07kwlFvqfv/xOLnJ5DquxSGQ==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.1.tgz",
+            "integrity": "sha512-vx1F37BRO1OftsYlmG9xay1TqnjNVlqALymwWVuYTdo18XuKxtBpCj1QlzNIEHlvlB27osvXFWptYiEWsVdYsg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.50.0",
-                "@typescript-eslint/types": "^8.50.0",
-                "debug": "^4.3.4"
+                "@typescript-eslint/tsconfig-utils": "^8.57.1",
+                "@typescript-eslint/types": "^8.57.1",
+                "debug": "^4.4.3"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1471,14 +1343,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.50.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.50.0.tgz",
-            "integrity": "sha512-xCwfuCZjhIqy7+HKxBLrDVT5q/iq7XBVBXLn57RTIIpelLtEIZHXAF/Upa3+gaCpeV1NNS5Z9A+ID6jn50VD4A==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.1.tgz",
+            "integrity": "sha512-hs/QcpCwlwT2L5S+3fT6gp0PabyGk4Q0Rv2doJXA0435/OpnSR3VRgvrp8Xdoc3UAYSg9cyUjTeFXZEPg/3OKg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.50.0",
-                "@typescript-eslint/visitor-keys": "8.50.0"
+                "@typescript-eslint/types": "8.57.1",
+                "@typescript-eslint/visitor-keys": "8.57.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1489,9 +1361,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.50.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.50.0.tgz",
-            "integrity": "sha512-vxd3G/ybKTSlm31MOA96gqvrRGv9RJ7LGtZCn2Vrc5htA0zCDvcMqUkifcjrWNNKXHUU3WCkYOzzVSFBd0wa2w==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.1.tgz",
+            "integrity": "sha512-0lgOZB8cl19fHO4eI46YUx2EceQqhgkPSuCGLlGi79L2jwYY1cxeYc1Nae8Aw1xjgW3PKVDLlr3YJ6Bxx8HkWg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1506,17 +1378,17 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.50.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.50.0.tgz",
-            "integrity": "sha512-7OciHT2lKCewR0mFoBrvZJ4AXTMe/sYOe87289WAViOocEmDjjv8MvIOT2XESuKj9jp8u3SZYUSh89QA4S1kQw==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.1.tgz",
+            "integrity": "sha512-+Bwwm0ScukFdyoJsh2u6pp4S9ktegF98pYUU0hkphOOqdMB+1sNQhIz8y5E9+4pOioZijrkfNO/HUJVAFFfPKA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.50.0",
-                "@typescript-eslint/typescript-estree": "8.50.0",
-                "@typescript-eslint/utils": "8.50.0",
-                "debug": "^4.3.4",
-                "ts-api-utils": "^2.1.0"
+                "@typescript-eslint/types": "8.57.1",
+                "@typescript-eslint/typescript-estree": "8.57.1",
+                "@typescript-eslint/utils": "8.57.1",
+                "debug": "^4.4.3",
+                "ts-api-utils": "^2.4.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1526,14 +1398,14 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0",
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.50.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.50.0.tgz",
-            "integrity": "sha512-iX1mgmGrXdANhhITbpp2QQM2fGehBse9LbTf0sidWK6yg/NE+uhV5dfU1g6EYPlcReYmkE9QLPq/2irKAmtS9w==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.1.tgz",
+            "integrity": "sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1545,21 +1417,21 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.50.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.50.0.tgz",
-            "integrity": "sha512-W7SVAGBR/IX7zm1t70Yujpbk+zdPq/u4soeFSknWFdXIFuWsBGBOUu/Tn/I6KHSKvSh91OiMuaSnYp3mtPt5IQ==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.1.tgz",
+            "integrity": "sha512-ybe2hS9G6pXpqGtPli9Gx9quNV0TWLOmh58ADlmZe9DguLq0tiAKVjirSbtM1szG6+QH6rVXyU6GTLQbWnMY+g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.50.0",
-                "@typescript-eslint/tsconfig-utils": "8.50.0",
-                "@typescript-eslint/types": "8.50.0",
-                "@typescript-eslint/visitor-keys": "8.50.0",
-                "debug": "^4.3.4",
-                "minimatch": "^9.0.4",
-                "semver": "^7.6.0",
+                "@typescript-eslint/project-service": "8.57.1",
+                "@typescript-eslint/tsconfig-utils": "8.57.1",
+                "@typescript-eslint/types": "8.57.1",
+                "@typescript-eslint/visitor-keys": "8.57.1",
+                "debug": "^4.4.3",
+                "minimatch": "^10.2.2",
+                "semver": "^7.7.3",
                 "tinyglobby": "^0.2.15",
-                "ts-api-utils": "^2.1.0"
+                "ts-api-utils": "^2.4.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1573,16 +1445,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.50.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.50.0.tgz",
-            "integrity": "sha512-87KgUXET09CRjGCi2Ejxy3PULXna63/bMYv72tCAlDJC3Yqwln0HiFJ3VJMst2+mEtNtZu5oFvX4qJGjKsnAgg==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.1.tgz",
+            "integrity": "sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@eslint-community/eslint-utils": "^4.7.0",
-                "@typescript-eslint/scope-manager": "8.50.0",
-                "@typescript-eslint/types": "8.50.0",
-                "@typescript-eslint/typescript-estree": "8.50.0"
+                "@eslint-community/eslint-utils": "^4.9.1",
+                "@typescript-eslint/scope-manager": "8.57.1",
+                "@typescript-eslint/types": "8.57.1",
+                "@typescript-eslint/typescript-estree": "8.57.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1592,19 +1464,19 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^8.57.0 || ^9.0.0",
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.50.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.50.0.tgz",
-            "integrity": "sha512-Xzmnb58+Db78gT/CCj/PVCvK+zxbnsw6F+O1oheYszJbBSdEjVhQi3C/Xttzxgi/GLmpvOggRs1RFpiJ8+c34Q==",
+            "version": "8.57.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.1.tgz",
+            "integrity": "sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.50.0",
-                "eslint-visitor-keys": "^4.2.1"
+                "@typescript-eslint/types": "8.57.1",
+                "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1615,43 +1487,42 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
-                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/@vitest/coverage-v8": {
-            "version": "4.0.16",
-            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.16.tgz",
-            "integrity": "sha512-2rNdjEIsPRzsdu6/9Eq0AYAzYdpP6Bx9cje9tL3FE5XzXRQF1fNU9pe/1yE8fCrS0HD+fBtt6gLPh6LI57tX7A==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.0.tgz",
+            "integrity": "sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@bcoe/v8-coverage": "^1.0.2",
-                "@vitest/utils": "4.0.16",
-                "ast-v8-to-istanbul": "^0.3.8",
+                "@vitest/utils": "4.1.0",
+                "ast-v8-to-istanbul": "^1.0.0",
                 "istanbul-lib-coverage": "^3.2.2",
                 "istanbul-lib-report": "^3.0.1",
-                "istanbul-lib-source-maps": "^5.0.6",
                 "istanbul-reports": "^3.2.0",
-                "magicast": "^0.5.1",
+                "magicast": "^0.5.2",
                 "obug": "^2.1.1",
-                "std-env": "^3.10.0",
+                "std-env": "^4.0.0-rc.1",
                 "tinyrainbow": "^3.0.3"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
-                "@vitest/browser": "4.0.16",
-                "vitest": "4.0.16"
+                "@vitest/browser": "4.1.0",
+                "vitest": "4.1.0"
             },
             "peerDependenciesMeta": {
                 "@vitest/browser": {
@@ -1660,17 +1531,17 @@
             }
         },
         "node_modules/@vitest/expect": {
-            "version": "4.0.16",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.16.tgz",
-            "integrity": "sha512-eshqULT2It7McaJkQGLkPjPjNph+uevROGuIMJdG3V+0BSR2w9u6J9Lwu+E8cK5TETlfou8GRijhafIMhXsimA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
+            "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@standard-schema/spec": "^1.0.0",
+                "@standard-schema/spec": "^1.1.0",
                 "@types/chai": "^5.2.2",
-                "@vitest/spy": "4.0.16",
-                "@vitest/utils": "4.0.16",
-                "chai": "^6.2.1",
+                "@vitest/spy": "4.1.0",
+                "@vitest/utils": "4.1.0",
+                "chai": "^6.2.2",
                 "tinyrainbow": "^3.0.3"
             },
             "funding": {
@@ -1678,13 +1549,13 @@
             }
         },
         "node_modules/@vitest/mocker": {
-            "version": "4.0.16",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.16.tgz",
-            "integrity": "sha512-yb6k4AZxJTB+q9ycAvsoxGn+j/po0UaPgajllBgt1PzoMAAmJGYFdDk0uCcRcxb3BrME34I6u8gHZTQlkqSZpg==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
+            "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "4.0.16",
+                "@vitest/spy": "4.1.0",
                 "estree-walker": "^3.0.3",
                 "magic-string": "^0.30.21"
             },
@@ -1693,7 +1564,7 @@
             },
             "peerDependencies": {
                 "msw": "^2.4.9",
-                "vite": "^6.0.0 || ^7.0.0-0"
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
             },
             "peerDependenciesMeta": {
                 "msw": {
@@ -1715,9 +1586,9 @@
             }
         },
         "node_modules/@vitest/pretty-format": {
-            "version": "4.0.16",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.16.tgz",
-            "integrity": "sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
+            "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1728,13 +1599,13 @@
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "4.0.16",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.16.tgz",
-            "integrity": "sha512-VWEDm5Wv9xEo80ctjORcTQRJ539EGPB3Pb9ApvVRAY1U/WkHXmmYISqU5E79uCwcW7xYUV38gwZD+RV755fu3Q==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
+            "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "4.0.16",
+                "@vitest/utils": "4.1.0",
                 "pathe": "^2.0.3"
             },
             "funding": {
@@ -1742,13 +1613,14 @@
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "4.0.16",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.16.tgz",
-            "integrity": "sha512-sf6NcrYhYBsSYefxnry+DR8n3UV4xWZwWxYbCJUt2YdvtqzSPR7VfGrY0zsv090DAbjFZsi7ZaMi1KnSRyK1XA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
+            "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.0.16",
+                "@vitest/pretty-format": "4.1.0",
+                "@vitest/utils": "4.1.0",
                 "magic-string": "^0.30.21",
                 "pathe": "^2.0.3"
             },
@@ -1757,9 +1629,9 @@
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "4.0.16",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.16.tgz",
-            "integrity": "sha512-4jIOWjKP0ZUaEmJm00E0cOBLU+5WE0BpeNr3XN6TEF05ltro6NJqHWxXD0kA8/Zc8Nh23AT8WQxwNG+WeROupw==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
+            "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -1767,13 +1639,14 @@
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "4.0.16",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.16.tgz",
-            "integrity": "sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
+            "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "4.0.16",
+                "@vitest/pretty-format": "4.1.0",
+                "convert-source-map": "^2.0.0",
                 "tinyrainbow": "^3.0.3"
             },
             "funding": {
@@ -1804,9 +1677,9 @@
             }
         },
         "node_modules/acorn-walk": {
-            "version": "8.3.5",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
-            "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+            "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1817,9 +1690,9 @@
             }
         },
         "node_modules/ajv": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-            "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1874,15 +1747,15 @@
             }
         },
         "node_modules/ast-v8-to-istanbul": {
-            "version": "0.3.8",
-            "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.8.tgz",
-            "integrity": "sha512-szgSZqUxI5T8mLKvS7WTjF9is+MVbOeLADU73IseOcrqhxr/VAvy6wfoVE39KnKzA7JRhjF5eUagNlHwvZPlKQ==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+            "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.31",
                 "estree-walker": "^3.0.3",
-                "js-tokens": "^9.0.1"
+                "js-tokens": "^10.0.0"
             }
         },
         "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
@@ -1903,13 +1776,26 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+            "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "balanced-match": "^1.0.0"
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/brace-expansion/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/buffer-from": {
@@ -2044,6 +1930,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/diff": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -2055,53 +1951,11 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-            "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+            "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/esbuild": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
-            "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "bin": {
-                "esbuild": "bin/esbuild"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.27.2",
-                "@esbuild/android-arm": "0.27.2",
-                "@esbuild/android-arm64": "0.27.2",
-                "@esbuild/android-x64": "0.27.2",
-                "@esbuild/darwin-arm64": "0.27.2",
-                "@esbuild/darwin-x64": "0.27.2",
-                "@esbuild/freebsd-arm64": "0.27.2",
-                "@esbuild/freebsd-x64": "0.27.2",
-                "@esbuild/linux-arm": "0.27.2",
-                "@esbuild/linux-arm64": "0.27.2",
-                "@esbuild/linux-ia32": "0.27.2",
-                "@esbuild/linux-loong64": "0.27.2",
-                "@esbuild/linux-mips64el": "0.27.2",
-                "@esbuild/linux-ppc64": "0.27.2",
-                "@esbuild/linux-riscv64": "0.27.2",
-                "@esbuild/linux-s390x": "0.27.2",
-                "@esbuild/linux-x64": "0.27.2",
-                "@esbuild/netbsd-arm64": "0.27.2",
-                "@esbuild/netbsd-x64": "0.27.2",
-                "@esbuild/openbsd-arm64": "0.27.2",
-                "@esbuild/openbsd-x64": "0.27.2",
-                "@esbuild/openharmony-arm64": "0.27.2",
-                "@esbuild/sunos-x64": "0.27.2",
-                "@esbuild/win32-arm64": "0.27.2",
-                "@esbuild/win32-ia32": "0.27.2",
-                "@esbuild/win32-x64": "0.27.2"
-            }
         },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
@@ -2288,9 +2142,9 @@
             }
         },
         "node_modules/eslint/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2385,9 +2239,9 @@
             }
         },
         "node_modules/expect-type": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
-            "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+            "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -2680,21 +2534,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/istanbul-lib-source-maps": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
-            "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@jridgewell/trace-mapping": "^0.3.23",
-                "debug": "^4.1.1",
-                "istanbul-lib-coverage": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/istanbul-reports": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
@@ -2710,9 +2549,9 @@
             }
         },
         "node_modules/js-tokens": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-            "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+            "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -2772,6 +2611,267 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/lightningcss": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.32.0",
+                "lightningcss-darwin-arm64": "1.32.0",
+                "lightningcss-darwin-x64": "1.32.0",
+                "lightningcss-freebsd-x64": "1.32.0",
+                "lightningcss-linux-arm-gnueabihf": "1.32.0",
+                "lightningcss-linux-arm64-gnu": "1.32.0",
+                "lightningcss-linux-arm64-musl": "1.32.0",
+                "lightningcss-linux-x64-gnu": "1.32.0",
+                "lightningcss-linux-x64-musl": "1.32.0",
+                "lightningcss-win32-arm64-msvc": "1.32.0",
+                "lightningcss-win32-x64-msvc": "1.32.0"
+            }
+        },
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
             }
         },
         "node_modules/locate-path": {
@@ -2843,16 +2943,16 @@
             "license": "ISC"
         },
         "node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "version": "10.2.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+            "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
             "dev": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^2.0.2"
+                "brace-expansion": "^5.0.2"
             },
             "engines": {
-                "node": ">=16 || 14 >=14.17"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -3128,12 +3228,47 @@
                 "node": ">=4"
             }
         },
-        "node_modules/rollup": {
-            "version": "4.59.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.1.tgz",
-            "integrity": "sha512-iZKH8BeoCwTCBTZBZWQQMreekd4mdomwdjIQ40GC1oZm6o+8PnNMIxFOiCsGMWeS8iDJ7KZcl7KwmKk/0HOQpA==",
+        "node_modules/rolldown": {
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.10.tgz",
+            "integrity": "sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA==",
             "dev": true,
             "license": "MIT",
+            "dependencies": {
+                "@oxc-project/types": "=0.120.0",
+                "@rolldown/pluginutils": "1.0.0-rc.10"
+            },
+            "bin": {
+                "rolldown": "bin/cli.mjs"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "optionalDependencies": {
+                "@rolldown/binding-android-arm64": "1.0.0-rc.10",
+                "@rolldown/binding-darwin-arm64": "1.0.0-rc.10",
+                "@rolldown/binding-darwin-x64": "1.0.0-rc.10",
+                "@rolldown/binding-freebsd-x64": "1.0.0-rc.10",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.10",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.10",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.10",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.10",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.10",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.10",
+                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.10",
+                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.10",
+                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.10",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.10",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.10"
+            }
+        },
+        "node_modules/rollup": {
+            "version": "4.53.3",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
+            "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -3145,31 +3280,28 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.59.1",
-                "@rollup/rollup-android-arm64": "4.59.1",
-                "@rollup/rollup-darwin-arm64": "4.59.1",
-                "@rollup/rollup-darwin-x64": "4.59.1",
-                "@rollup/rollup-freebsd-arm64": "4.59.1",
-                "@rollup/rollup-freebsd-x64": "4.59.1",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.59.1",
-                "@rollup/rollup-linux-arm-musleabihf": "4.59.1",
-                "@rollup/rollup-linux-arm64-gnu": "4.59.1",
-                "@rollup/rollup-linux-arm64-musl": "4.59.1",
-                "@rollup/rollup-linux-loong64-gnu": "4.59.1",
-                "@rollup/rollup-linux-loong64-musl": "4.59.1",
-                "@rollup/rollup-linux-ppc64-gnu": "4.59.1",
-                "@rollup/rollup-linux-ppc64-musl": "4.59.1",
-                "@rollup/rollup-linux-riscv64-gnu": "4.59.1",
-                "@rollup/rollup-linux-riscv64-musl": "4.59.1",
-                "@rollup/rollup-linux-s390x-gnu": "4.59.1",
-                "@rollup/rollup-linux-x64-gnu": "4.59.1",
-                "@rollup/rollup-linux-x64-musl": "4.59.1",
-                "@rollup/rollup-openbsd-x64": "4.59.1",
-                "@rollup/rollup-openharmony-arm64": "4.59.1",
-                "@rollup/rollup-win32-arm64-msvc": "4.59.1",
-                "@rollup/rollup-win32-ia32-msvc": "4.59.1",
-                "@rollup/rollup-win32-x64-gnu": "4.59.1",
-                "@rollup/rollup-win32-x64-msvc": "4.59.1",
+                "@rollup/rollup-android-arm-eabi": "4.53.3",
+                "@rollup/rollup-android-arm64": "4.53.3",
+                "@rollup/rollup-darwin-arm64": "4.53.3",
+                "@rollup/rollup-darwin-x64": "4.53.3",
+                "@rollup/rollup-freebsd-arm64": "4.53.3",
+                "@rollup/rollup-freebsd-x64": "4.53.3",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.53.3",
+                "@rollup/rollup-linux-arm-musleabihf": "4.53.3",
+                "@rollup/rollup-linux-arm64-gnu": "4.53.3",
+                "@rollup/rollup-linux-arm64-musl": "4.53.3",
+                "@rollup/rollup-linux-loong64-gnu": "4.53.3",
+                "@rollup/rollup-linux-ppc64-gnu": "4.53.3",
+                "@rollup/rollup-linux-riscv64-gnu": "4.53.3",
+                "@rollup/rollup-linux-riscv64-musl": "4.53.3",
+                "@rollup/rollup-linux-s390x-gnu": "4.53.3",
+                "@rollup/rollup-linux-x64-gnu": "4.53.3",
+                "@rollup/rollup-linux-x64-musl": "4.53.3",
+                "@rollup/rollup-openharmony-arm64": "4.53.3",
+                "@rollup/rollup-win32-arm64-msvc": "4.53.3",
+                "@rollup/rollup-win32-ia32-msvc": "4.53.3",
+                "@rollup/rollup-win32-x64-gnu": "4.53.3",
+                "@rollup/rollup-win32-x64-msvc": "4.53.3",
                 "fsevents": "~2.3.2"
             }
         },
@@ -3200,9 +3332,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+            "version": "7.7.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+            "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -3298,9 +3430,9 @@
             "license": "MIT"
         },
         "node_modules/std-env": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-            "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+            "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -3386,9 +3518,9 @@
             "license": "MIT"
         },
         "node_modules/tinyexec": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-            "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+            "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3423,9 +3555,9 @@
             }
         },
         "node_modules/ts-api-utils": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-            "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+            "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3539,17 +3671,16 @@
             "license": "MIT"
         },
         "node_modules/vite": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
-            "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.1.tgz",
+            "integrity": "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "esbuild": "^0.27.0",
-                "fdir": "^6.5.0",
+                "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.3",
-                "postcss": "^8.5.6",
-                "rollup": "^4.43.0",
+                "postcss": "^8.5.8",
+                "rolldown": "1.0.0-rc.10",
                 "tinyglobby": "^0.2.15"
             },
             "bin": {
@@ -3566,9 +3697,10 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.1.0",
+                "esbuild": "^0.27.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
-                "lightningcss": "^1.21.0",
                 "sass": "^1.70.0",
                 "sass-embedded": "^1.70.0",
                 "stylus": ">=0.54.8",
@@ -3581,13 +3713,16 @@
                 "@types/node": {
                     "optional": true
                 },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
                 "jiti": {
                     "optional": true
                 },
                 "less": {
-                    "optional": true
-                },
-                "lightningcss": {
                     "optional": true
                 },
                 "sass": {
@@ -3614,31 +3749,31 @@
             }
         },
         "node_modules/vitest": {
-            "version": "4.0.16",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.16.tgz",
-            "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
+            "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/expect": "4.0.16",
-                "@vitest/mocker": "4.0.16",
-                "@vitest/pretty-format": "4.0.16",
-                "@vitest/runner": "4.0.16",
-                "@vitest/snapshot": "4.0.16",
-                "@vitest/spy": "4.0.16",
-                "@vitest/utils": "4.0.16",
-                "es-module-lexer": "^1.7.0",
-                "expect-type": "^1.2.2",
+                "@vitest/expect": "4.1.0",
+                "@vitest/mocker": "4.1.0",
+                "@vitest/pretty-format": "4.1.0",
+                "@vitest/runner": "4.1.0",
+                "@vitest/snapshot": "4.1.0",
+                "@vitest/spy": "4.1.0",
+                "@vitest/utils": "4.1.0",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
                 "magic-string": "^0.30.21",
                 "obug": "^2.1.1",
                 "pathe": "^2.0.3",
                 "picomatch": "^4.0.3",
-                "std-env": "^3.10.0",
+                "std-env": "^4.0.0-rc.1",
                 "tinybench": "^2.9.0",
                 "tinyexec": "^1.0.2",
                 "tinyglobby": "^0.2.15",
                 "tinyrainbow": "^3.0.3",
-                "vite": "^6.0.0 || ^7.0.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
                 "why-is-node-running": "^2.3.0"
             },
             "bin": {
@@ -3654,12 +3789,13 @@
                 "@edge-runtime/vm": "*",
                 "@opentelemetry/api": "^1.9.0",
                 "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-                "@vitest/browser-playwright": "4.0.16",
-                "@vitest/browser-preview": "4.0.16",
-                "@vitest/browser-webdriverio": "4.0.16",
-                "@vitest/ui": "4.0.16",
+                "@vitest/browser-playwright": "4.1.0",
+                "@vitest/browser-preview": "4.1.0",
+                "@vitest/browser-webdriverio": "4.1.0",
+                "@vitest/ui": "4.1.0",
                 "happy-dom": "*",
-                "jsdom": "*"
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
             },
             "peerDependenciesMeta": {
                 "@edge-runtime/vm": {
@@ -3688,6 +3824,9 @@
                 },
                 "jsdom": {
                     "optional": true
+                },
+                "vite": {
+                    "optional": false
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "odata-builder",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "Type-safe OData v4.01 query builder for TypeScript with compile-time validation. Fluent FilterBuilder API, lambda expressions (any/all), in/not/has operators.",
     "author": "Marcel Wenner (https://github.com/marcelwenner)",
     "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 export { OdataQueryBuilder } from './query-builder/index';
 export { SearchExpressionBuilder } from './query-builder/builder/search-expression-builder';
-export { FilterBuilder, filter } from './query-builder/builder/filter-builder/index';
+export {
+    FilterBuilder,
+    filter,
+} from './query-builder/builder/filter-builder/index';
 export type {
     FilterExpression,
     FieldProxy,

--- a/src/query-builder/builder/filter-builder/field-proxy.ts
+++ b/src/query-builder/builder/filter-builder/field-proxy.ts
@@ -10,7 +10,16 @@ import {
 // Known Operations - Used to distinguish field access from method calls
 // ============================================================================
 
-const COMPARISON_OPS = ['eq', 'ne', 'gt', 'ge', 'lt', 'le', 'in', 'has'] as const;
+const COMPARISON_OPS = [
+    'eq',
+    'ne',
+    'gt',
+    'ge',
+    'lt',
+    'le',
+    'in',
+    'has',
+] as const;
 const STRING_PREDICATES = ['contains', 'startswith', 'endswith'] as const;
 const STRING_FUNCTIONS = ['length', 'indexof', 'substring', 'concat'] as const;
 const STRING_TRANSFORMS = ['tolower', 'toupper', 'trim'] as const;

--- a/src/query-builder/builder/filter-builder/filter-builder.test.ts
+++ b/src/query-builder/builder/filter-builder/filter-builder.test.ts
@@ -97,6 +97,56 @@ describe('FilterBuilder', () => {
         });
     });
 
+    describe('String Comparison Operations', () => {
+        it('should build gt filter for string', () => {
+            const result = new FilterBuilder<TestUser>()
+                .where(x => x.name.gt('M'))
+                .build();
+
+            expect(result).toEqual({
+                field: 'name',
+                operator: 'gt',
+                value: 'M',
+            });
+        });
+
+        it('should build ge filter for string', () => {
+            const result = new FilterBuilder<TestUser>()
+                .where(x => x.name.ge('M'))
+                .build();
+
+            expect(result).toEqual({
+                field: 'name',
+                operator: 'ge',
+                value: 'M',
+            });
+        });
+
+        it('should build lt filter for string', () => {
+            const result = new FilterBuilder<TestUser>()
+                .where(x => x.name.lt('Z'))
+                .build();
+
+            expect(result).toEqual({
+                field: 'name',
+                operator: 'lt',
+                value: 'Z',
+            });
+        });
+
+        it('should build le filter for string', () => {
+            const result = new FilterBuilder<TestUser>()
+                .where(x => x.name.le('Z'))
+                .build();
+
+            expect(result).toEqual({
+                field: 'name',
+                operator: 'le',
+                value: 'Z',
+            });
+        });
+    });
+
     describe('Number Operations', () => {
         it('should build gt filter', () => {
             const result = new FilterBuilder<TestUser>()

--- a/src/query-builder/builder/filter-builder/filter-builder.test.ts
+++ b/src/query-builder/builder/filter-builder/filter-builder.test.ts
@@ -809,7 +809,9 @@ describe('FilterBuilder', () => {
 
         it('should build nested array filter', () => {
             const result = new FilterBuilder<TestUser>()
-                .where(x => x.orders.any(o => o.items.any(i => i.quantity.gt(5))))
+                .where(x =>
+                    x.orders.any(o => o.items.any(i => i.quantity.gt(5))),
+                )
                 .build();
 
             expect(result).toEqual({
@@ -937,10 +939,8 @@ describe('FilterBuilder', () => {
 
         it('should throw error for empty values array', () => {
             expect(() => {
-                new FilterBuilder<TestUser>()
-                    .where(x => x.name.in([]))
-                    .build();
-            }).toThrow("FilterBuilder: in() requires at least one value");
+                new FilterBuilder<TestUser>().where(x => x.name.in([])).build();
+            }).toThrow('FilterBuilder: in() requires at least one value');
         });
 
         it('should build in filter with null values for nullable fields', () => {
@@ -1006,7 +1006,7 @@ describe('FilterBuilder', () => {
         it('should throw error when using not() on empty builder', () => {
             expect(() => {
                 new FilterBuilder<TestUser>().not();
-            }).toThrow("FilterBuilder: Cannot use .not() on empty builder");
+            }).toThrow('FilterBuilder: Cannot use .not() on empty builder');
         });
 
         it('should allow chaining after not()', () => {
@@ -1021,7 +1021,11 @@ describe('FilterBuilder', () => {
                 filters: [
                     {
                         type: 'not',
-                        filter: { field: 'name', operator: 'eq', value: 'John' },
+                        filter: {
+                            field: 'name',
+                            operator: 'eq',
+                            value: 'John',
+                        },
                     },
                     { field: 'isActive', operator: 'eq', value: true },
                 ],
@@ -1063,7 +1067,11 @@ describe('FilterBuilder', () => {
             expect(result).toEqual({
                 logic: 'and',
                 filters: [
-                    { field: 'name', operator: 'has', value: "Namespace.Permission'Admin'" },
+                    {
+                        field: 'name',
+                        operator: 'has',
+                        value: "Namespace.Permission'Admin'",
+                    },
                     { field: 'isActive', operator: 'eq', value: true },
                 ],
             });
@@ -1121,7 +1129,9 @@ describe('FilterBuilder', () => {
 describe('createFieldProxy', () => {
     it('should return undefined for symbol properties', () => {
         const proxy = createFieldProxy<TestUser>();
-        expect((proxy as unknown as Record<symbol, unknown>)[Symbol('test')]).toBeUndefined();
+        expect(
+            (proxy as unknown as Record<symbol, unknown>)[Symbol('test')],
+        ).toBeUndefined();
     });
 
     it('should throw for unknown operations', () => {
@@ -1147,11 +1157,7 @@ describe('OdataQueryBuilder.filter() with FilterBuilder', () => {
 
     it('should work with complex filter', () => {
         const query = new OdataQueryBuilder<TestUser>()
-            .filter(f =>
-                f
-                    .where(x => x.name.eq('John'))
-                    .and(x => x.age.gt(18)),
-            )
+            .filter(f => f.where(x => x.name.eq('John')).and(x => x.age.gt(18)))
             .toQuery();
 
         expect(query).toBe("?$filter=(name eq 'John' and age gt 18)");
@@ -1216,9 +1222,7 @@ describe('OdataQueryBuilder.filter() with FilterBuilder', () => {
     it('should work with OR combined filter', () => {
         const query = new OdataQueryBuilder<TestUser>()
             .filter(f =>
-                f
-                    .where(x => x.name.eq('John'))
-                    .or(x => x.name.eq('Jane')),
+                f.where(x => x.name.eq('John')).or(x => x.name.eq('Jane')),
             )
             .toQuery();
 
@@ -1240,7 +1244,9 @@ describe('OdataQueryBuilder.filter() with FilterBuilder', () => {
             .top(10)
             .toQuery();
 
-        expect(query).toBe('?$filter=isActive eq true&$top=10&$select=name, age');
+        expect(query).toBe(
+            '?$filter=isActive eq true&$top=10&$select=name, age',
+        );
     });
 
     it('should still support object-based filter', () => {
@@ -1321,9 +1327,7 @@ describe('FilterBuilder Apostrophe Escaping', () => {
 
     it('should escape apostrophes in lambda expressions', () => {
         const query = new OdataQueryBuilder<TestUser>()
-            .filter(f =>
-                f.where(x => x.tags.any(t => t.s.eq("dev's"))),
-            )
+            .filter(f => f.where(x => x.tags.any(t => t.s.eq("dev's"))))
             .toQuery();
 
         expect(query).toBe("?$filter=tags/any(s: s eq 'dev''s')");

--- a/src/query-builder/builder/filter-builder/filter-builder.ts
+++ b/src/query-builder/builder/filter-builder/filter-builder.ts
@@ -66,10 +66,7 @@ export class FilterBuilder<T> implements FilterBuilderLike<T> {
             return this;
         }
 
-        return new FilterBuilder<T>([
-            ...this.parts,
-            { filter },
-        ]);
+        return new FilterBuilder<T>([...this.parts, { filter }]);
     }
 
     /**
@@ -93,10 +90,7 @@ export class FilterBuilder<T> implements FilterBuilderLike<T> {
             return this;
         }
 
-        return new FilterBuilder<T>([
-            ...this.parts,
-            { logic: 'and', filter },
-        ]);
+        return new FilterBuilder<T>([...this.parts, { logic: 'and', filter }]);
     }
 
     /**
@@ -120,10 +114,7 @@ export class FilterBuilder<T> implements FilterBuilderLike<T> {
             return this;
         }
 
-        return new FilterBuilder<T>([
-            ...this.parts,
-            { logic: 'or', filter },
-        ]);
+        return new FilterBuilder<T>([...this.parts, { logic: 'or', filter }]);
     }
 
     /**

--- a/src/query-builder/builder/filter-builder/filter-builder.types.test.ts
+++ b/src/query-builder/builder/filter-builder/filter-builder.types.test.ts
@@ -124,9 +124,8 @@ describe('Forbidden Operations', () => {
         });
     });
 
-    it('should NOT allow gt on string', () => {
+    it('should allow gt on string (lexicographic comparison)', () => {
         new FilterBuilder<User>().where(x => {
-            // @ts-expect-error - gt is not on StringFieldOperations
             return x.name.gt('test');
         });
     });

--- a/src/query-builder/builder/filter-builder/filter-builder.types.test.ts
+++ b/src/query-builder/builder/filter-builder/filter-builder.types.test.ts
@@ -432,7 +432,9 @@ describe('Edge Cases', () => {
     describe('Readonly', () => {
         it('readonly fields work normally', () => {
             type Item = { readonly name: string };
-            const result = new FilterBuilder<Item>().where(x => x.name.eq('test'));
+            const result = new FilterBuilder<Item>().where(x =>
+                x.name.eq('test'),
+            );
             assertType<FilterBuilder<Item>>(result);
         });
 
@@ -555,7 +557,9 @@ describe('String ops - full coverage', () => {
         new FilterBuilder<SimpleUser>().where(x => x.name.indexof('x').eq(0));
     });
     it('substring', () => {
-        new FilterBuilder<SimpleUser>().where(x => x.name.substring(0, 5).eq('x'));
+        new FilterBuilder<SimpleUser>().where(x =>
+            x.name.substring(0, 5).eq('x'),
+        );
     });
     it('concat', () => {
         new FilterBuilder<SimpleUser>().where(x => x.name.concat('x').eq('x'));
@@ -707,10 +711,14 @@ describe('Array ops - full coverage', () => {
     type SimpleUser = { tags: string[]; orders: { price: number }[] };
 
     it('any on primitive array', () => {
-        new FilterBuilder<SimpleUser>().where(x => x.tags.any(t => t.s.eq('x')));
+        new FilterBuilder<SimpleUser>().where(x =>
+            x.tags.any(t => t.s.eq('x')),
+        );
     });
     it('all on primitive array', () => {
-        new FilterBuilder<SimpleUser>().where(x => x.tags.all(t => t.s.eq('x')));
+        new FilterBuilder<SimpleUser>().where(x =>
+            x.tags.all(t => t.s.eq('x')),
+        );
     });
     it('any on object array', () => {
         new FilterBuilder<SimpleUser>().where(x =>

--- a/src/query-builder/builder/filter-builder/filter-builder.types.ts
+++ b/src/query-builder/builder/filter-builder/filter-builder.types.ts
@@ -62,7 +62,10 @@ export interface StringFieldOperations<
     // String functions returning values (can be chained with comparison)
     length(): NumberFieldOperations<T>;
     indexof(value: string): NumberFieldOperations<T>;
-    substring(start: number, length?: number): StringFieldOperations<T, string, AllowNull>;
+    substring(
+        start: number,
+        length?: number,
+    ): StringFieldOperations<T, string, AllowNull>;
     concat(...values: string[]): StringFieldOperations<T, string, AllowNull>;
 
     // String transforms
@@ -165,8 +168,12 @@ export interface GuidFieldOperations<
  * Array-specific operations (for lambda filters)
  */
 export interface ArrayFieldOperations<T, E> {
-    any(predicate: (element: FieldProxy<E>) => FilterExpression<E>): FilterExpression<T>;
-    all(predicate: (element: FieldProxy<E>) => FilterExpression<E>): FilterExpression<T>;
+    any(
+        predicate: (element: FieldProxy<E>) => FilterExpression<E>,
+    ): FilterExpression<T>;
+    all(
+        predicate: (element: FieldProxy<E>) => FilterExpression<E>,
+    ): FilterExpression<T>;
 }
 
 // ============================================================================
@@ -189,13 +196,10 @@ export type PrimitiveArrayWrapper<V> = { s: V };
  * Uses [V] extends [...] pattern to prevent distributive conditional types
  * This ensures literal unions like 'open' | 'closed' are preserved as-is
  */
- 
-/* eslint-disable @typescript-eslint/no-redundant-type-constituents */
-type FieldOperationsFor<
-    TRoot,
+
+type FieldOperationsFor<TRoot, V, AllowNull extends boolean = false> = [
     V,
-    AllowNull extends boolean = false,
-> = [V] extends [Guid]
+] extends [Guid]
     ? GuidFieldOperations<TRoot, AllowNull>
     : [V] extends [string]
       ? StringFieldOperations<TRoot, V & string, AllowNull>
@@ -212,7 +216,6 @@ type FieldOperationsFor<
               : [V] extends [object]
                 ? NestedFieldProxy<TRoot, V>
                 : never;
-/* eslint-enable @typescript-eslint/no-redundant-type-constituents */
 
 /**
  * NestedFieldProxy for accessing nested object properties while preserving the root type
@@ -220,7 +223,11 @@ type FieldOperationsFor<
  * T is the current nested object type (for property access)
  */
 export type NestedFieldProxy<TRoot, T> = {
-    [K in keyof T]-?: FieldOperationsFor<TRoot, NonNullable<T[K]>, IncludesNull<T[K]>>;
+    [K in keyof T]-?: FieldOperationsFor<
+        TRoot,
+        NonNullable<T[K]>,
+        IncludesNull<T[K]>
+    >;
 };
 
 /**
@@ -236,7 +243,11 @@ export type NestedFieldProxy<TRoot, T> = {
  * // - x.nullableName (string | null) -> StringFieldOperations<User, string, true>  (allows eq(null))
  */
 export type FieldProxy<T> = {
-    [K in keyof T]-?: FieldOperationsFor<T, NonNullable<T[K]>, IncludesNull<T[K]>>;
+    [K in keyof T]-?: FieldOperationsFor<
+        T,
+        NonNullable<T[K]>,
+        IncludesNull<T[K]>
+    >;
 };
 
 // ============================================================================

--- a/src/query-builder/builder/filter-builder/filter-builder.types.ts
+++ b/src/query-builder/builder/filter-builder/filter-builder.types.ts
@@ -70,6 +70,12 @@ export interface StringFieldOperations<
     toupper(): StringFieldOperations<T, V, AllowNull>;
     trim(): StringFieldOperations<T, V, AllowNull>;
 
+    // Comparison operators (lexicographic - OData v4.01 spec 5.1.1.1.3)
+    gt(value: V): FilterExpression<T>;
+    ge(value: V): FilterExpression<T>;
+    lt(value: V): FilterExpression<T>;
+    le(value: V): FilterExpression<T>;
+
     /**
      * Enum flag check using 'has' operator
      * Value must be a valid OData enum literal (e.g., "Sales.Color'Yellow'")

--- a/src/query-builder/query-builder.test.ts
+++ b/src/query-builder/query-builder.test.ts
@@ -171,31 +171,31 @@ describe('query-builder', () => {
         expect(queryBuilder.toQuery()).toBe(expectedQuery);
     });
 
-    it.each([
-        { ignoreCase: true },
-        { ignoreCase: false },
-    ])('should add a contains filter to the query', filterOption => {
-        type ItemType = {
-            x: string;
-        };
+    it.each([{ ignoreCase: true }, { ignoreCase: false }])(
+        'should add a contains filter to the query',
+        filterOption => {
+            type ItemType = {
+                x: string;
+            };
 
-        const filter = {
-            field: 'x' as const,
-            function: { type: 'contains' as const, value: '1' },
-            operator: 'eq' as const,
-            value: true,
-            ignoreCase: filterOption.ignoreCase,
-        };
+            const filter = {
+                field: 'x' as const,
+                function: { type: 'contains' as const, value: '1' },
+                operator: 'eq' as const,
+                value: true,
+                ignoreCase: filterOption.ignoreCase,
+            };
 
-        const expectedQuery = `?$filter=contains(${filterOption.ignoreCase ? 'tolower(' : ''}x${
-            filterOption.ignoreCase ? ')' : ''
-        }, '1')`;
+            const expectedQuery = `?$filter=contains(${filterOption.ignoreCase ? 'tolower(' : ''}x${
+                filterOption.ignoreCase ? ')' : ''
+            }, '1')`;
 
-        const queryBuilder = new OdataQueryBuilder<ItemType>();
-        queryBuilder.filter(filter);
+            const queryBuilder = new OdataQueryBuilder<ItemType>();
+            queryBuilder.filter(filter);
 
-        expect(queryBuilder.toQuery()).toBe(expectedQuery);
-    });
+            expect(queryBuilder.toQuery()).toBe(expectedQuery);
+        },
+    );
 
     it('should add space before and when combining two filters', () => {
         interface MyAwesomeDto {
@@ -981,8 +981,8 @@ describe('OdataQueryBuilder with in operator', () => {
     type ItemType = { status: string; age: number; name: string };
 
     it('should generate OData 4.01 in syntax by default', () => {
-        const queryBuilder = new OdataQueryBuilder<ItemType>().filter(
-            f => f.where(x => x.status.in(['active', 'pending'])),
+        const queryBuilder = new OdataQueryBuilder<ItemType>().filter(f =>
+            f.where(x => x.status.in(['active', 'pending'])),
         );
 
         expect(queryBuilder.toQuery()).toBe(
@@ -1001,16 +1001,16 @@ describe('OdataQueryBuilder with in operator', () => {
     });
 
     it('should handle in filter with number values', () => {
-        const queryBuilder = new OdataQueryBuilder<ItemType>().filter(
-            f => f.where(x => x.age.in([18, 21, 65])),
+        const queryBuilder = new OdataQueryBuilder<ItemType>().filter(f =>
+            f.where(x => x.age.in([18, 21, 65])),
         );
 
         expect(queryBuilder.toQuery()).toBe('?$filter=age in (18, 21, 65)');
     });
 
     it('should escape single quotes in values', () => {
-        const queryBuilder = new OdataQueryBuilder<ItemType>().filter(
-            f => f.where(x => x.name.in(["O'Reilly", "McDonald's"])),
+        const queryBuilder = new OdataQueryBuilder<ItemType>().filter(f =>
+            f.where(x => x.name.in(["O'Reilly", "McDonald's"])),
         );
 
         expect(queryBuilder.toQuery()).toBe(
@@ -1019,11 +1019,10 @@ describe('OdataQueryBuilder with in operator', () => {
     });
 
     it('should combine in filter with other filters', () => {
-        const queryBuilder = new OdataQueryBuilder<ItemType>().filter(
-            f =>
-                f
-                    .where(x => x.status.in(['active', 'pending']))
-                    .and(x => x.age.gt(18)),
+        const queryBuilder = new OdataQueryBuilder<ItemType>().filter(f =>
+            f
+                .where(x => x.status.in(['active', 'pending']))
+                .and(x => x.age.gt(18)),
         );
 
         expect(queryBuilder.toQuery()).toBe(
@@ -1034,11 +1033,10 @@ describe('OdataQueryBuilder with in operator', () => {
     it('should use parentheses correctly in legacy mode with combined filters', () => {
         const queryBuilder = new OdataQueryBuilder<ItemType>({
             legacyInOperator: true,
-        }).filter(
-            f =>
-                f
-                    .where(x => x.status.in(['active', 'pending']))
-                    .and(x => x.age.gt(18)),
+        }).filter(f =>
+            f
+                .where(x => x.status.in(['active', 'pending']))
+                .and(x => x.age.gt(18)),
         );
 
         expect(queryBuilder.toQuery()).toBe(
@@ -1051,20 +1049,19 @@ describe('OdataQueryBuilder with not operator', () => {
     type ItemType = { name: string; age: number; isActive: boolean };
 
     it('should negate a simple filter', () => {
-        const queryBuilder = new OdataQueryBuilder<ItemType>().filter(
-            f => f.where(x => x.name.eq('John')).not(),
+        const queryBuilder = new OdataQueryBuilder<ItemType>().filter(f =>
+            f.where(x => x.name.eq('John')).not(),
         );
 
         expect(queryBuilder.toQuery()).toBe("?$filter=not (name eq 'John')");
     });
 
     it('should negate a combined filter', () => {
-        const queryBuilder = new OdataQueryBuilder<ItemType>().filter(
-            f =>
-                f
-                    .where(x => x.name.eq('John'))
-                    .and(x => x.age.gt(18))
-                    .not(),
+        const queryBuilder = new OdataQueryBuilder<ItemType>().filter(f =>
+            f
+                .where(x => x.name.eq('John'))
+                .and(x => x.age.gt(18))
+                .not(),
         );
 
         expect(queryBuilder.toQuery()).toBe(
@@ -1073,20 +1070,21 @@ describe('OdataQueryBuilder with not operator', () => {
     });
 
     it('should negate a contains filter', () => {
-        const queryBuilder = new OdataQueryBuilder<ItemType>().filter(
-            f => f.where(x => x.name.contains('test')).not(),
+        const queryBuilder = new OdataQueryBuilder<ItemType>().filter(f =>
+            f.where(x => x.name.contains('test')).not(),
         );
 
-        expect(queryBuilder.toQuery()).toBe("?$filter=not (contains(name, 'test'))");
+        expect(queryBuilder.toQuery()).toBe(
+            "?$filter=not (contains(name, 'test'))",
+        );
     });
 
     it('should chain not with other filters', () => {
-        const queryBuilder = new OdataQueryBuilder<ItemType>().filter(
-            f =>
-                f
-                    .where(x => x.name.eq('John'))
-                    .not()
-                    .and(x => x.isActive.isTrue()),
+        const queryBuilder = new OdataQueryBuilder<ItemType>().filter(f =>
+            f
+                .where(x => x.name.eq('John'))
+                .not()
+                .and(x => x.isActive.isTrue()),
         );
 
         expect(queryBuilder.toQuery()).toBe(

--- a/src/query-builder/types/expand/expand-fields.type.test.ts
+++ b/src/query-builder/types/expand/expand-fields.type.test.ts
@@ -27,9 +27,7 @@ describe('ExpandFields<T>', () => {
     describe('with interface types', () => {
         it('should work with interface properties', () => {
             expectTypeOf<ExpandFields<User>>().toEqualTypeOf<
-                | 'address'
-                | 'company'
-                | 'company/location'
+                'address' | 'company' | 'company/location'
             >();
         });
 

--- a/src/query-builder/types/expand/expand-fields.type.ts
+++ b/src/query-builder/types/expand/expand-fields.type.ts
@@ -9,7 +9,7 @@ export type ExpandFields<T, Depth extends number = 5> = Depth extends 0
               ? // Check for empty object
                 HasKeys<NonNullable<T[K]>> extends true
                   ? // If there's at least one key, include `K` and deeper expansions
-                    | K
+                        | K
                         | (Depth extends 1
                               ? never
                               : `${K}/${ExpandFields<NonNullable<T[K]>, PrevDepth<Depth>>}`)

--- a/src/query-builder/types/filter/combined-filter.type.test.ts
+++ b/src/query-builder/types/filter/combined-filter.type.test.ts
@@ -12,7 +12,12 @@ describe('CombinedFilter<T>', () => {
                 {
                     logic: 'or',
                     filters: [
-                        { field: 'name', function: { type: 'contains', value: 'test' }, operator: 'eq', value: true },
+                        {
+                            field: 'name',
+                            function: { type: 'contains', value: 'test' },
+                            operator: 'eq',
+                            value: true,
+                        },
                     ],
                 },
             ],
@@ -39,7 +44,12 @@ describe('CombinedFilter<T>', () => {
                 {
                     logic: 'or',
                     filters: [
-                        { field: 'name', function: { type: 'contains', value: 'test' }, operator: 'eq', value: true },
+                        {
+                            field: 'name',
+                            function: { type: 'contains', value: 'test' },
+                            operator: 'eq',
+                            value: true,
+                        },
                         {
                             logic: 'and',
                             filters: [
@@ -100,7 +110,12 @@ describe('CombinedFilter<T>', () => {
                 {
                     logic: 'or',
                     filters: [
-                        { field: 'name', function: { type: 'contains', value: 'test' }, operator: 'eq', value: true },
+                        {
+                            field: 'name',
+                            function: { type: 'contains', value: 'test' },
+                            operator: 'eq',
+                            value: true,
+                        },
                         {
                             logic: 'and',
                             filters: [

--- a/src/query-builder/types/filter/query-filter.type.ts
+++ b/src/query-builder/types/filter/query-filter.type.ts
@@ -295,7 +295,9 @@ export type LambdaFilterFields<T, VALUETYPE> = {
 
 export type GeneralFilterOperators = 'eq' | 'ne';
 
-export type StringFilterOperators = GeneralFilterOperators | NumberFilterOperators;
+export type StringFilterOperators =
+    | GeneralFilterOperators
+    | NumberFilterOperators;
 
 export type StringTransform = 'tolower' | 'toupper' | 'trim' | 'length';
 export type DateTransform =

--- a/src/query-builder/types/filter/query-filter.type.ts
+++ b/src/query-builder/types/filter/query-filter.type.ts
@@ -295,7 +295,7 @@ export type LambdaFilterFields<T, VALUETYPE> = {
 
 export type GeneralFilterOperators = 'eq' | 'ne';
 
-export type StringFilterOperators = GeneralFilterOperators;
+export type StringFilterOperators = GeneralFilterOperators | NumberFilterOperators;
 
 export type StringTransform = 'tolower' | 'toupper' | 'trim' | 'length';
 export type DateTransform =

--- a/src/query-builder/types/orderby/orderby-descriptor.type.ts
+++ b/src/query-builder/types/orderby/orderby-descriptor.type.ts
@@ -5,8 +5,6 @@ export interface OrderByDescriptor<T> {
     orderDirection: 'asc' | 'desc';
 }
 
- 
-/* eslint-disable @typescript-eslint/no-redundant-type-constituents */
 export type OrderByFields<T, Depth extends number = 5> = [Depth] extends [never]
     ? never
     : {
@@ -23,4 +21,3 @@ export type OrderByFields<T, Depth extends number = 5> = [Depth] extends [never]
                           : `${K}/${OrderByFields<NonNullable<T[K]>, PrevDepth<Depth>> & string}`)
               : K;
       }[Extract<keyof T, string>];
-/* eslint-enable @typescript-eslint/no-redundant-type-constituents */

--- a/src/query-builder/types/select/select-fields.type.ts
+++ b/src/query-builder/types/select/select-fields.type.ts
@@ -19,8 +19,7 @@ import { IsObjectType, PrevDepth } from '../utils/util.types';
  * type Fields = SelectFields<User>;
  * // 'name' | 'address' | 'address/city' | 'address/zip'
  */
- 
-/* eslint-disable @typescript-eslint/no-redundant-type-constituents */
+
 export type SelectFields<T, Depth extends number = 5> = [Depth] extends [never]
     ? never
     : {
@@ -37,4 +36,3 @@ export type SelectFields<T, Depth extends number = 5> = [Depth] extends [never]
                           : `${K}/${SelectFields<NonNullable<T[K]>, PrevDepth<Depth>> & string}`)
               : K;
       }[Extract<keyof T, string>];
-/* eslint-enable @typescript-eslint/no-redundant-type-constituents */

--- a/src/query-builder/types/utils/util.types.ts
+++ b/src/query-builder/types/utils/util.types.ts
@@ -31,10 +31,10 @@ export type IsObjectType<T> = T extends object
     ? T extends readonly unknown[]
         ? false
         : T extends (...args: unknown[]) => unknown
+          ? false
+          : T extends Date
             ? false
-            : T extends Date
-                ? false
-                : true
+            : true
     : false;
 
 export type PrevDepth<T extends number> = [

--- a/src/query-builder/utils/filter/filter-helper.util.test.ts
+++ b/src/query-builder/utils/filter/filter-helper.util.test.ts
@@ -58,7 +58,9 @@ describe('isGuid', () => {
         });
 
         it('rejects GUIDs with braces', () => {
-            expect(isGuid('{550e8400-e29b-41d4-a716-446655440000}')).toBe(false);
+            expect(isGuid('{550e8400-e29b-41d4-a716-446655440000}')).toBe(
+                false,
+            );
         });
     });
 });

--- a/src/query-builder/utils/filter/filter-helper.util.ts
+++ b/src/query-builder/utils/filter/filter-helper.util.ts
@@ -4,6 +4,10 @@ export const operatorTypeMap: Record<string, string[]> = {
     string: [
         'eq',
         'ne',
+        'gt',
+        'ge',
+        'lt',
+        'le',
         'contains',
         'startswith',
         'endswith',

--- a/src/query-builder/utils/filter/filter-visitor.test.ts
+++ b/src/query-builder/utils/filter/filter-visitor.test.ts
@@ -492,7 +492,9 @@ describe('ODataFilterVisitor with in operator', () => {
         let visitor: ODataFilterVisitor<ItemType>;
 
         beforeEach(() => {
-            visitor = new ODataFilterVisitor<ItemType>({ legacyInOperator: true });
+            visitor = new ODataFilterVisitor<ItemType>({
+                legacyInOperator: true,
+            });
         });
 
         it('should use or fallback for string values', () => {
@@ -739,7 +741,9 @@ describe('ODataFilterVisitor with has operator', () => {
 
         const result = visitor.visitCombinedFilter(filter);
 
-        expect(result).toBe("(color eq 'Blue' or style has Sales.Color'Yellow')");
+        expect(result).toBe(
+            "(color eq 'Blue' or style has Sales.Color'Yellow')",
+        );
     });
 });
 
@@ -818,7 +822,7 @@ describe('ODataFilterVisitor Apostrophe Escaping', () => {
             field: 'name',
             operator: 'eq',
             value: 'result',
-            function: { type: 'concat', values: ["John's", "book"] },
+            function: { type: 'concat', values: ["John's", 'book'] },
         };
 
         const result = visitor.visitBasicFilter(filter);

--- a/src/query-builder/utils/filter/filter-visitor.ts
+++ b/src/query-builder/utils/filter/filter-visitor.ts
@@ -87,8 +87,8 @@ export class ODataFilterVisitor<T> implements FilterVisitor<T> {
 
             const value =
                 'removeQuotes' in filter && filter.removeQuotes
-                ? escapedValue
-                : `'${escapedValue}'`;
+                    ? escapedValue
+                    : `'${escapedValue}'`;
 
             if ('function' in filter && filter.function) {
                 const fieldForFunction =
@@ -249,7 +249,9 @@ export class ODataFilterVisitor<T> implements FilterVisitor<T> {
                     return this.visitInFilter(prefixedFilter);
                 }
                 if (isNegatedFilter(subFilter)) {
-                    return this.visitNegatedFilter(subFilter as NegatedFilter<U>);
+                    return this.visitNegatedFilter(
+                        subFilter as NegatedFilter<U>,
+                    );
                 }
                 if (isHasFilter(subFilter)) {
                     const prefixedFilter = {
@@ -284,9 +286,7 @@ export class ODataFilterVisitor<T> implements FilterVisitor<T> {
 
     visitInFilter(filter: InFilter): string {
         const field = String(filter.field);
-        const formattedValues = filter.values.map(v =>
-            this.formatInValue(v),
-        );
+        const formattedValues = filter.values.map(v => this.formatInValue(v));
 
         if (this.context.legacyInOperator) {
             // OData 4.0 fallback: (field eq v1 or field eq v2 or ...)
@@ -347,10 +347,14 @@ export class ODataFilterVisitor<T> implements FilterVisitor<T> {
         if (typeof value === 'number' || typeof value === 'boolean') {
             return String(value);
         }
-        throw new Error(`Unsupported value type in 'in' filter: ${typeof value}`);
+        throw new Error(
+            `Unsupported value type in 'in' filter: ${typeof value}`,
+        );
     }
 
-    private getTransformedField<U>(filter: Exclude<QueryFilter<U>, NegatedFilter<U>>): string {
+    private getTransformedField<U>(
+        filter: Exclude<QueryFilter<U>, NegatedFilter<U>>,
+    ): string {
         // Alle definierten Transformationen zusammenfassen
         const transforms = [
             ...('ignoreCase' in filter && filter.ignoreCase ? ['tolower'] : []),

--- a/src/query-builder/utils/filter/is-query-filter-util.test.ts
+++ b/src/query-builder/utils/filter/is-query-filter-util.test.ts
@@ -9,7 +9,12 @@ describe('isQueryFilter', () => {
     describe('Basic Filters', () => {
         it.each([
             { field: 'isActive', operator: 'eq', value: true },
-            { field: 'name', function: { type: 'contains', value: 'test' }, operator: 'eq', value: true },
+            {
+                field: 'name',
+                function: { type: 'contains', value: 'test' },
+                operator: 'eq',
+                value: true,
+            },
             { field: 'createdAt', operator: 'gt', value: testDate },
             { field: 'id', operator: 'eq', value: testGuid },
             { field: 'age', operator: 'lt', value: 30 },
@@ -127,9 +132,7 @@ describe('isQueryFilter', () => {
                 // Cast to basic filter type since we know this specific filter has a value property
                 const basicFilter = potentialFilter as { value: unknown };
                 expect(basicFilter.value instanceof Date).toBe(true);
-                expect(
-                    (basicFilter.value as Date).toISOString(),
-                ).toBeDefined();
+                expect((basicFilter.value as Date).toISOString()).toBeDefined();
             } else {
                 expect.fail(
                     'Filter should have been recognized as QueryFilter',

--- a/src/query-builder/utils/filter/is-query-filter-util.test.ts
+++ b/src/query-builder/utils/filter/is-query-filter-util.test.ts
@@ -54,7 +54,6 @@ describe('isQueryFilter', () => {
             { field: 'name' },
             { operator: 'eq' },
             { value: 'test' },
-            { field: 'age', operator: 'lt', value: 'thirty' },
             { field: 'tags', lambdaOperator: 'any' },
             { lambdaOperator: 'any', expression: {} },
             { field: 'tags', expression: {} },

--- a/src/query-builder/utils/filter/is-query-filter-util.ts
+++ b/src/query-builder/utils/filter/is-query-filter-util.ts
@@ -72,5 +72,5 @@ export const isQueryFilter = <T>(filter: unknown): filter is QueryFilter<T> => {
         return true;
     }
 
-    return false
+    return false;
 };


### PR DESCRIPTION
## Summary
- Add `gt`, `ge`, `lt`, `le` operators to `StringFieldOperations` for lexicographic string comparison per OData v4.01 spec (section 5.1.1.1.3)
- Update `StringFilterOperators` type, runtime `operatorTypeMap`, and tests
- Bump version to 1.0.4

Closes #133

## Test plan
- [x] All 616 existing tests pass
- [x] 4 new tests for string comparison operators (gt/ge/lt/le)
- [x] Type test updated to verify string gt is allowed
- [x] Build succeeds