### PR TITLE
feat: expand now supports subqueries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Subquery support for `expand()`** with full OData system query options
+
+    - Supports `$select`, `$filter`, `$orderby`, `$top`, `$skip`, `$count`, `$search`, and nested `$expand`
+    - Mix simple string paths and subquery objects in a single call
+    - Deeply nested expand with recursive subquery options
+    - New exported types: `ExpandInput`, `ExpandSubQueryOptions`, `ExpandWithSubQuery`, `TopLevelExpandFields`
+
+    ```typescript
+    builder.expand({
+        orders: {
+            select: ['id', 'total'],
+            filter: f => f.where(x => x.total.gt(100)),
+            top: 5,
+            expand: [{ items: { select: ['name', 'price'] } }],
+        },
+    });
+    // $expand=orders($select=id, total;$filter=total gt 100;$top=5;$expand=items($select=name, price))
+    ```
+
 ## [1.0.0] - 2025-12-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -316,12 +316,51 @@ new OdataQueryBuilder<User>()
 
 ### expand
 
-Include related entities. Supports nested paths:
+Include related entities. Supports nested paths and **subqueries** with `$select`, `$filter`, `$orderby`, `$top`, `$skip`, `$count`, `$search`, and nested `$expand`:
 
 ```typescript
+// Simple expand
 new OdataQueryBuilder<User>().expand('company', 'company/address').toQuery();
-// ?$expand=company,company/address
+// ?$expand=company, company/address
+
+// Expand with subquery options
+new OdataQueryBuilder<User>()
+    .expand({
+        company: {
+            select: ['name', 'location'],
+            filter: f => f.where(x => x.name.contains('Corp')),
+            orderBy: [{ field: 'name', orderDirection: 'asc' }],
+            top: 5,
+        },
+    })
+    .toQuery();
+// ?$expand=company($select=name, location;$filter=contains(name, 'Corp');$orderby=name asc;$top=5)
+
+// Nested expand with subqueries (deeply nested)
+new OdataQueryBuilder<User>()
+    .expand({
+        company: {
+            select: ['name'],
+            expand: [{
+                address: {
+                    select: ['city', 'zip'],
+                },
+            }],
+        },
+    })
+    .toQuery();
+// ?$expand=company($select=name;$expand=address($select=city, zip))
+
+// Mix simple and subquery expands
+new OdataQueryBuilder<User>()
+    .expand('company/address', {
+        orders: { top: 10, orderBy: [{ field: 'date', orderDirection: 'desc' }] },
+    })
+    .toQuery();
+// ?$expand=company/address, orders($top=10;$orderby=date desc)
 ```
+
+**Subquery options**: `select`, `filter`, `orderBy`, `top`, `skip`, `count`, `search`, `expand`
 
 ### orderBy
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,12 @@ export type {
 export type { CombinedFilter } from './query-builder/types/filter/combined-filter.type';
 export type { Guid } from './query-builder/types/utils/util.types';
 export type { ExpandFields } from './query-builder/types/expand/expand-fields.type';
+export type {
+    ExpandInput,
+    ExpandSubQueryOptions,
+    ExpandWithSubQuery,
+    TopLevelExpandFields,
+} from './query-builder/types/expand/expand-descriptor.type';
 
 export { isCombinedFilter } from './query-builder/utils/filter/combined-filter-util';
 export { isQueryFilter } from './query-builder/utils/filter/is-query-filter-util';

--- a/src/query-builder/index.ts
+++ b/src/query-builder/index.ts
@@ -12,7 +12,7 @@ import {
     FilterRenderContext,
 } from './utils/filter/filter-utils';
 import { CombinedFilter } from './types/filter/combined-filter.type';
-import { ExpandFields } from './types/expand/expand-fields.type';
+import { ExpandInput } from './types/expand/expand-descriptor.type';
 import { toExpandQuery } from './utils/expand/expand-util';
 import { toTopQuery } from './utils/top/top-utils';
 import { toSkipQuery } from './utils/skip/skip-utils';
@@ -269,21 +269,45 @@ export class OdataQueryBuilder<T> {
     /**
      * Expands navigation properties to include related entities.
      *
-     * @param expandFields - Navigation properties to expand
+     * Supports both simple string paths and objects with nested subquery options
+     * ($select, $filter, $orderby, $top, $skip, $count, $search, and nested $expand).
+     *
+     * @param expandFields - Navigation properties to expand, either as string paths
+     *                        or objects with subquery options
      * @returns This builder for chaining
      * @throws Error if any expand field is invalid
      *
      * @example
+     * // Simple expand
      * builder.expand('orders')  // $expand=orders
      *
      * @example
-     * // Nested expand with select
-     * builder.expand({ orders: { select: ['id', 'price'] } })
+     * // Expand with subquery options
+     * builder.expand({
+     *     orders: {
+     *         select: ['id', 'price'],
+     *         filter: f => f.where(x => x.price.gt(100)),
+     *         top: 5,
+     *         orderBy: [{ field: 'price', orderDirection: 'desc' }]
+     *     }
+     * })
+     * // $expand=orders($select=id, price;$filter=price gt 100;$orderby=price desc;$top=5)
+     *
+     * @example
+     * // Nested expand with subqueries
+     * builder.expand({
+     *     orders: {
+     *         select: ['id'],
+     *         expand: [{ items: { select: ['name', 'price'] } }]
+     *     }
+     * })
+     * // $expand=orders($select=id;$expand=items($select=name, price))
      */
-    expand(...expandFields: ExpandFields<T>[]): this {
+    expand(...expandFields: ExpandInput<T>[]): this {
         if (expandFields.length === 0) return this;
-        if (expandFields.some(field => !field))
-            throw new Error('Field missing for expand');
+        for (const field of expandFields) {
+            if (!field) throw new Error('Field missing for expand');
+        }
 
         return this.addComponent('expand', expandFields);
     }
@@ -413,7 +437,10 @@ export class OdataQueryBuilder<T> {
                     Array.from(component as Set<Extract<keyof T, string>>),
                 ),
             expand: component =>
-                toExpandQuery<T>(Array.from(component as Set<ExpandFields<T>>)),
+                toExpandQuery<T>(
+                    Array.from(component as Set<ExpandInput<T>>),
+                    this.filterContext,
+                ),
             orderBy: component =>
                 toOrderByQuery(
                     Array.from(component as Set<OrderByDescriptor<T>>),

--- a/src/query-builder/types/expand/expand-descriptor.type.test.ts
+++ b/src/query-builder/types/expand/expand-descriptor.type.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import {
+    TopLevelExpandFields,
+    ExpandWithSubQuery,
+    ExpandInput,
+    ExpandSubQueryOptions,
+} from './expand-descriptor.type';
+
+// ============================================================================
+// Test interfaces
+// ============================================================================
+
+interface Address {
+    street: string;
+    city: string;
+}
+
+interface OrderItem {
+    name: string;
+    price: number;
+    category: {
+        id: number;
+        label: string;
+    };
+}
+
+interface Order {
+    id: number;
+    total: number;
+    items: OrderItem;
+    customer: {
+        name: string;
+        address: Address;
+    };
+}
+
+interface Entity {
+    name: string;
+    age: number;
+    orders: Order;
+    details: { info: string };
+}
+
+describe('TopLevelExpandFields<T>', () => {
+    it('should extract only top-level navigation properties', () => {
+        expectTypeOf<TopLevelExpandFields<Entity>>().toEqualTypeOf<
+            'orders' | 'details'
+        >();
+    });
+
+    it('should not include primitive fields', () => {
+        type OnlyPrimitives = { name: string; count: number };
+        expectTypeOf<TopLevelExpandFields<OnlyPrimitives>>().toEqualTypeOf<never>();
+    });
+
+    it('should handle nested objects', () => {
+        expectTypeOf<TopLevelExpandFields<Order>>().toEqualTypeOf<
+            'items' | 'customer'
+        >();
+    });
+});
+
+describe('ExpandWithSubQuery<T>', () => {
+    it('should allow subquery options for navigation properties', () => {
+        type Result = ExpandWithSubQuery<Entity>;
+        // Should accept valid subquery
+        const valid: Result = {
+            orders: { select: ['id', 'total'], top: 5 },
+        };
+        expectTypeOf(valid).toMatchTypeOf<Result>();
+    });
+
+    it('should allow partial navigation properties', () => {
+        type Result = ExpandWithSubQuery<Entity>;
+        const partial: Result = { orders: { top: 10 } };
+        expectTypeOf(partial).toMatchTypeOf<Result>();
+    });
+
+    it('should allow nested expand in subquery options', () => {
+        type OrderOptions = ExpandSubQueryOptions<Order>;
+        const nested: OrderOptions = {
+            select: ['id'],
+            expand: [{ items: { select: ['name'] } }],
+        };
+        expectTypeOf(nested).toMatchTypeOf<OrderOptions>();
+    });
+});
+
+describe('ExpandInput<T>', () => {
+    it('should accept simple string paths', () => {
+        const simple: ExpandInput<Entity> = 'orders';
+        expectTypeOf(simple).toMatchTypeOf<ExpandInput<Entity>>();
+    });
+
+    it('should accept subquery objects', () => {
+        const withSubQuery: ExpandInput<Entity> = {
+            orders: { select: ['id'], top: 5 },
+        };
+        expectTypeOf(withSubQuery).toMatchTypeOf<ExpandInput<Entity>>();
+    });
+
+    it('should accept nested path strings', () => {
+        const nested: ExpandInput<Entity> = 'orders/items';
+        expectTypeOf(nested).toMatchTypeOf<ExpandInput<Entity>>();
+    });
+});

--- a/src/query-builder/types/expand/expand-descriptor.type.ts
+++ b/src/query-builder/types/expand/expand-descriptor.type.ts
@@ -1,0 +1,75 @@
+import { SelectFields } from '../select/select-fields.type';
+import { OrderByDescriptor } from '../orderby/orderby-descriptor.type';
+import { HasKeys, IsExpandableType, UnwrapArray } from '../utils/util.types';
+import { ExpandFields } from './expand-fields.type';
+import { FilterBuilder } from '../../builder/filter-builder/filter-builder';
+import { SearchExpressionBuilder } from '../../builder/search-expression-builder';
+
+/**
+ * Extracts only the top-level navigation property names from a type.
+ * Unlike ExpandFields which generates slash-separated nested paths,
+ * this only returns direct object-typed keys.
+ */
+export type TopLevelExpandFields<T> = {
+    [K in Extract<keyof T, string>]: IsExpandableType<
+        NonNullable<T[K]>
+    > extends true
+        ? HasKeys<NonNullable<UnwrapArray<T[K]>>> extends true
+            ? K
+            : never
+        : never;
+}[Extract<keyof T, string>];
+
+/**
+ * Subquery options for an expanded navigation property.
+ *
+ * Supports all OData system query options that can be applied
+ * within an $expand clause.
+ *
+ * @typeParam T - The entity type of the navigation property being expanded
+ *
+ * @example
+ * // $expand=orders($select=id, price;$top=5;$orderby=price desc)
+ * {
+ *     select: ['id', 'price'],
+ *     top: 5,
+ *     orderBy: [{ field: 'price', orderDirection: 'desc' }]
+ * }
+ */
+export interface ExpandSubQueryOptions<T> {
+    select?: SelectFields<Required<T>>[];
+    filter?: (
+        f: FilterBuilder<Required<T>>,
+    ) => FilterBuilder<Required<T>>;
+    orderBy?: OrderByDescriptor<Required<T>>[];
+    top?: number;
+    skip?: number;
+    count?: boolean;
+    search?: string | SearchExpressionBuilder;
+    expand?: ExpandInput<T>[];
+}
+
+/**
+ * An expand descriptor that maps navigation property names to their
+ * subquery options. Each key must be a top-level navigation property.
+ *
+ * @typeParam T - The parent entity type
+ *
+ * @example
+ * // For entity { orders: Order[]; details: Detail }
+ * { orders: { select: ['id'], top: 10 } }
+ */
+export type ExpandWithSubQuery<T> = {
+    [K in TopLevelExpandFields<Required<T>>]?: ExpandSubQueryOptions<
+        NonNullable<UnwrapArray<Required<T>[K]>>
+    >;
+};
+
+/**
+ * Input type for the expand method. Accepts either:
+ * - A simple string path (e.g., 'orders' or 'orders/items')
+ * - An object mapping navigation properties to subquery options
+ *
+ * @typeParam T - The entity type
+ */
+export type ExpandInput<T> = ExpandFields<T> | ExpandWithSubQuery<T>;

--- a/src/query-builder/types/expand/expand-fields.type.ts
+++ b/src/query-builder/types/expand/expand-fields.type.ts
@@ -1,18 +1,18 @@
-import { HasKeys, IsObjectType, PrevDepth } from '../utils/util.types';
+import { HasKeys, IsExpandableType, PrevDepth, UnwrapArray } from '../utils/util.types';
 
 export type ExpandFields<T, Depth extends number = 5> = Depth extends 0
     ? never
     : {
-          [K in Extract<keyof T, string>]: IsObjectType<
+          [K in Extract<keyof T, string>]: IsExpandableType<
               NonNullable<T[K]>
           > extends true
-              ? // Check for empty object
-                HasKeys<NonNullable<T[K]>> extends true
+              ? // Check for empty object (unwrap arrays first)
+                HasKeys<NonNullable<UnwrapArray<T[K]>>> extends true
                   ? // If there's at least one key, include `K` and deeper expansions
                         | K
                         | (Depth extends 1
                               ? never
-                              : `${K}/${ExpandFields<NonNullable<T[K]>, PrevDepth<Depth>>}`)
+                              : `${K}/${ExpandFields<NonNullable<UnwrapArray<T[K]>>, PrevDepth<Depth>>}`)
                   : never
               : never;
       }[Extract<keyof T, string>];

--- a/src/query-builder/types/utils/util.types.ts
+++ b/src/query-builder/types/utils/util.types.ts
@@ -1,7 +1,7 @@
 import { CombinedFilter } from '../filter/combined-filter.type';
 import { QueryFilter } from '../filter/query-filter.type';
 import { OrderByDescriptor } from '../orderby/orderby-descriptor.type';
-import { ExpandFields } from '../expand/expand-fields.type';
+import { ExpandInput } from '../expand/expand-descriptor.type';
 import { SelectFields } from '../select/select-fields.type';
 
 export type Guid = string & { _type: Guid };
@@ -17,7 +17,7 @@ export interface QueryComponents<T> {
     skip?: number;
     select?: Set<SelectFields<Required<T>>>;
     orderBy?: Set<OrderByDescriptor<T>>;
-    expand?: Set<ExpandFields<Required<T>>>;
+    expand?: Set<ExpandInput<Required<T>>>;
     search?: string;
 }
 
@@ -45,3 +45,21 @@ export type PrevDepth<T extends number> = [
     3, // 4
     4, // 5
 ][T];
+
+/**
+ * Unwraps an array type to its element type.
+ * If T is not an array, returns T unchanged.
+ */
+export type UnwrapArray<T> = T extends readonly (infer U)[] ? U : T;
+
+/**
+ * Checks if a type represents an expandable navigation property:
+ * either a plain object or an array of objects.
+ */
+export type IsExpandableType<T> = IsObjectType<T> extends true
+    ? true
+    : T extends readonly (infer U)[]
+      ? IsObjectType<NonNullable<U>> extends true
+          ? true
+          : false
+      : false;

--- a/src/query-builder/utils/expand/expand-util.test.ts
+++ b/src/query-builder/utils/expand/expand-util.test.ts
@@ -34,4 +34,217 @@ describe('expand-util', () => {
         const result = toExpandQuery<typeof item>([]);
         expect(result).toBe('');
     });
+
+    describe('nested subqueries', () => {
+        interface OrderItem {
+            name: string;
+            price: number;
+            category: {
+                id: number;
+                label: string;
+            };
+        }
+
+        interface Order {
+            id: number;
+            total: number;
+            items: OrderItem;
+            customer: {
+                name: string;
+                address: {
+                    city: string;
+                    zip: string;
+                };
+            };
+        }
+
+        interface Entity {
+            name: string;
+            orders: Order;
+            details: { info: string };
+        }
+
+        it('should expand with $select subquery', () => {
+            const result = toExpandQuery<Entity>([
+                { orders: { select: ['id', 'total'] } },
+            ]);
+            expect(result).toBe('$expand=orders($select=id, total)');
+        });
+
+        it('should expand with $top subquery', () => {
+            const result = toExpandQuery<Entity>([
+                { orders: { top: 5 } },
+            ]);
+            expect(result).toBe('$expand=orders($top=5)');
+        });
+
+        it('should expand with $skip subquery', () => {
+            const result = toExpandQuery<Entity>([
+                { orders: { skip: 10 } },
+            ]);
+            expect(result).toBe('$expand=orders($skip=10)');
+        });
+
+        it('should expand with $count subquery', () => {
+            const result = toExpandQuery<Entity>([
+                { orders: { count: true } },
+            ]);
+            expect(result).toBe('$expand=orders($count=true)');
+        });
+
+        it('should expand with $orderby subquery', () => {
+            const result = toExpandQuery<Entity>([
+                {
+                    orders: {
+                        orderBy: [{ field: 'total', orderDirection: 'desc' }],
+                    },
+                },
+            ]);
+            expect(result).toBe('$expand=orders($orderby=total desc)');
+        });
+
+        it('should expand with $filter subquery using FilterBuilder', () => {
+            const result = toExpandQuery<Entity>([
+                {
+                    orders: {
+                        filter: f => f.where(x => x.total.gt(100)),
+                    },
+                },
+            ]);
+            expect(result).toBe('$expand=orders($filter=total gt 100)');
+        });
+
+        it('should expand with $search subquery', () => {
+            const result = toExpandQuery<Entity>([
+                { orders: { search: 'urgent' } },
+            ]);
+            expect(result).toBe('$expand=orders($search=urgent)');
+        });
+
+        it('should expand with multiple subquery options', () => {
+            const result = toExpandQuery<Entity>([
+                {
+                    orders: {
+                        select: ['id', 'total'],
+                        filter: f => f.where(x => x.total.gt(50)),
+                        orderBy: [{ field: 'total', orderDirection: 'desc' }],
+                        top: 10,
+                        skip: 5,
+                        count: true,
+                    },
+                },
+            ]);
+            expect(result).toBe(
+                '$expand=orders($select=id, total;$filter=total gt 50;$orderby=total desc;$top=10;$skip=5;$count=true)',
+            );
+        });
+
+        it('should expand multiple navigation properties with subqueries', () => {
+            const result = toExpandQuery<Entity>([
+                { orders: { top: 5 } },
+                { details: { select: ['info'] } },
+            ]);
+            expect(result).toBe(
+                '$expand=orders($top=5), details($select=info)',
+            );
+        });
+
+        it('should mix simple expand with subquery expand', () => {
+            const result = toExpandQuery<Entity>([
+                'details',
+                { orders: { select: ['id'], top: 3 } },
+            ]);
+            expect(result).toBe(
+                '$expand=details, orders($select=id;$top=3)',
+            );
+        });
+
+        it('should support nested $expand subqueries', () => {
+            const result = toExpandQuery<Entity>([
+                {
+                    orders: {
+                        select: ['id'],
+                        expand: [
+                            {
+                                items: {
+                                    select: ['name', 'price'],
+                                },
+                            },
+                        ],
+                    },
+                },
+            ]);
+            expect(result).toBe(
+                '$expand=orders($select=id;$expand=items($select=name, price))',
+            );
+        });
+
+        it('should support deeply nested $expand subqueries', () => {
+            const result = toExpandQuery<Entity>([
+                {
+                    orders: {
+                        expand: [
+                            {
+                                items: {
+                                    expand: [
+                                        {
+                                            category: {
+                                                select: ['label'],
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                    },
+                },
+            ]);
+            expect(result).toBe(
+                '$expand=orders($expand=items($expand=category($select=label)))',
+            );
+        });
+
+        it('should support nested $expand with filter', () => {
+            const result = toExpandQuery<Entity>([
+                {
+                    orders: {
+                        expand: [
+                            {
+                                customer: {
+                                    expand: [
+                                        {
+                                            address: {
+                                                select: ['city'],
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                        filter: f => f.where(x => x.total.gt(0)),
+                    },
+                },
+            ]);
+            expect(result).toBe(
+                '$expand=orders($filter=total gt 0;$expand=customer($expand=address($select=city)))',
+            );
+        });
+
+        it('should handle multiple properties in a single subquery object', () => {
+            const result = toExpandQuery<Entity>([
+                {
+                    orders: { top: 5 },
+                    details: { select: ['info'] },
+                },
+            ]);
+            expect(result).toBe(
+                '$expand=orders($top=5), details($select=info)',
+            );
+        });
+
+        it('should handle subquery with empty options as simple expand', () => {
+            const result = toExpandQuery<Entity>([{ orders: {} }]);
+            expect(result).toBe('$expand=orders');
+        });
+    });
 });

--- a/src/query-builder/utils/expand/expand-util.ts
+++ b/src/query-builder/utils/expand/expand-util.ts
@@ -1,7 +1,163 @@
-import { ExpandFields } from '../../types/expand/expand-fields.type';
+import {
+    ExpandInput,
+    ExpandSubQueryOptions,
+    ExpandWithSubQuery,
+} from '../../types/expand/expand-descriptor.type';
+import { CombinedFilter } from '../../types/filter/combined-filter.type';
+import { QueryFilter } from '../../types/filter/query-filter.type';
+import { toSelectQuery } from '../select/select-utils';
+import { toOrderByQuery } from '../orderby/orderby-utils';
+import { toTopQuery } from '../top/top-utils';
+import { toSkipQuery } from '../skip/skip-utils';
+import {
+    toFilterQuery,
+    FilterRenderContext,
+} from '../filter/filter-utils';
+import { FilterBuilder } from '../../builder/filter-builder/filter-builder';
+import { createSearchTerm } from '../search/search.utils';
 
-export const toExpandQuery = <T>(expandProps: ExpandFields<T>[]): string => {
+/**
+ * Checks if an expand input is a subquery object (not a simple string path).
+ */
+function isExpandWithSubQuery<T>(
+    input: ExpandInput<T>,
+): input is ExpandWithSubQuery<T> {
+    return typeof input === 'object' && input !== null;
+}
+
+/**
+ * Renders the subquery options for an expanded navigation property.
+ *
+ * @example
+ * renderSubQuery({ select: ['id', 'name'], top: 5 })
+ * // "($select=id, name;$top=5)"
+ */
+function renderSubQuery<T>(
+    options: ExpandSubQueryOptions<T>,
+    filterContext: FilterRenderContext = {},
+): string {
+    const parts: string[] = [];
+
+    if (options.select && options.select.length > 0) {
+        parts.push(toSelectQuery(options.select));
+    }
+
+    if (options.filter) {
+        const builder = options.filter(new FilterBuilder<Required<T>>());
+        const filterResult = builder.build();
+        if (filterResult) {
+            const filters: Array<QueryFilter<T> | CombinedFilter<T>> = [
+                filterResult as QueryFilter<T> | CombinedFilter<T>,
+            ];
+            const filterStr = toFilterQuery(filters, filterContext);
+            if (filterStr) parts.push(filterStr);
+        }
+    }
+
+    if (options.orderBy && options.orderBy.length > 0) {
+        const orderByStr = toOrderByQuery(options.orderBy);
+        if (orderByStr) parts.push(orderByStr);
+    }
+
+    if (options.top !== undefined && options.top > 0) {
+        parts.push(toTopQuery(options.top));
+    }
+
+    if (options.skip !== undefined && options.skip > 0) {
+        parts.push(toSkipQuery(options.skip));
+    }
+
+    if (options.count === true) {
+        parts.push('$count=true');
+    }
+
+    if (options.search) {
+        const searchStr =
+            typeof options.search === 'string'
+                ? createSearchTerm(options.search)
+                : options.search.toString();
+        parts.push(`$search=${encodeURIComponent(searchStr)}`);
+    }
+
+    if (options.expand && options.expand.length > 0) {
+        const nestedExpand = toExpandQueryInternal(
+            options.expand,
+            filterContext,
+        );
+        if (nestedExpand) parts.push(nestedExpand);
+    }
+
+    return parts.length > 0 ? `(${parts.join(';')})` : '';
+}
+
+/**
+ * Renders a single expand input item to its OData string representation.
+ */
+function renderExpandItem<T>(
+    input: ExpandInput<T>,
+    filterContext: FilterRenderContext = {},
+): string {
+    if (typeof input === 'string') {
+        return input;
+    }
+
+    if (isExpandWithSubQuery(input)) {
+        const entries = Object.entries(input) as [
+            string,
+            ExpandSubQueryOptions<unknown>,
+        ][];
+        return entries
+            .map(([field, options]) => {
+                if (!options || Object.keys(options).length === 0) {
+                    return field;
+                }
+                return `${field}${renderSubQuery(options, filterContext)}`;
+            })
+            .join(', ');
+    }
+
+    return String(input);
+}
+
+/**
+ * Internal implementation that builds the full $expand=... string.
+ */
+function toExpandQueryInternal<T>(
+    expandProps: ExpandInput<T>[],
+    filterContext: FilterRenderContext = {},
+): string {
     if (expandProps.length === 0) return '';
 
-    return `$expand=${expandProps.join(', ')}`;
-};
+    const rendered = expandProps
+        .map(item => renderExpandItem(item, filterContext))
+        .filter(Boolean)
+        .join(', ');
+
+    return rendered ? `$expand=${rendered}` : '';
+}
+
+/**
+ * Converts expand inputs to an OData $expand query string.
+ *
+ * Supports both simple field paths and nested subqueries.
+ *
+ * @example
+ * // Simple expand
+ * toExpandQuery(['orders'])  // "$expand=orders"
+ *
+ * @example
+ * // Expand with subquery
+ * toExpandQuery([{ orders: { select: ['id'], top: 5 } }])
+ * // "$expand=orders($select=id;$top=5)"
+ *
+ * @example
+ * // Nested expand with subqueries
+ * toExpandQuery([{ orders: { expand: [{ items: { select: ['name'] } }] } }])
+ * // "$expand=orders($expand=items($select=name))"
+ */
+export function toExpandQuery<T>(
+    expandProps: ExpandInput<T>[],
+    filterContext: FilterRenderContext = {},
+): string {
+    return toExpandQueryInternal(expandProps, filterContext);
+}


### PR DESCRIPTION
Add full OData system query options support for `$expand` subqueries.

### What changed

`expand()` now accepts subquery objects alongside simple string paths, enabling nested query options within expanded navigation properties.

Supported subquery options:
- `$select`, `$filter`, `$orderby`, `$top`, `$skip`, `$count`, `$search`
- Nested `$expand` with recursive subquery support

### Example

```typescript
builder.expand({
    orders: {
        select: ['id', 'total'],
        filter: f => f.where(x => x.total.gt(100)),
        top: 5,
        expand: [{ items: { select: ['name', 'price'] } }],
    },
});
// $expand=orders($select=id, total;$filter=total gt 100;$top=5;$expand=items($select=name, price))
```

### New exported types

- `ExpandInput`
- `ExpandSubQueryOptions`
- `ExpandWithSubQuery`
- `TopLevelExpandFields`
